### PR TITLE
fix: honor OpenAI-compatible provider base in MVP server

### DIFF
--- a/docker-compose.mvp.yml
+++ b/docker-compose.mvp.yml
@@ -95,6 +95,10 @@ services:
       # .env; see .env.example.
       - AGENT_RUNTIME_SECRET=${AGENT_RUNTIME_SECRET:?AGENT_RUNTIME_SECRET is required in .env — see .env.example (openssl rand -hex 32)}
       - OPENAI_API_KEY
+      # Keep the provider base consistent between LingxiGraph and the
+      # LingxiLoop server-side support/triage client. Unset means the OpenAI
+      # SDK default endpoint; set it for any OpenAI-compatible provider.
+      - OPENAI_BASE_URL
       # Bare-name passthrough (see lingxigraph-runtime above for why): an
       # unset OPENAI_MODEL / OPENAI_MODEL_SUPPORT must stay UNSET so
       # env.ts's own `?? 'gpt-5.5'` / `?? 'gpt-5.4-mini'` defaults apply,

--- a/server/src/llm.ts
+++ b/server/src/llm.ts
@@ -9,7 +9,8 @@
  *
  *   2. Else (sub2api unconfigured, or new tenant without a provisioned
  *      key yet) → legacy single `env.OPENAI_API_KEY` client pointed at
- *      OpenAI directly. No quotas — same behavior as pre-sub2api.
+ *      `OPENAI_BASE_URL` when configured, otherwise OpenAI directly.
+ *      No quotas — same behavior as pre-sub2api for the default case.
  *
  * Callers pass `tenant` (= company_id). When `tenant` is null (e.g.
  * platform-wide tasks like the avatar regen of a seeded agent before
@@ -118,6 +119,7 @@ let _legacy: OpenAI | null = null
 function legacyClient(): OpenAI {
   if (!_legacy) _legacy = new OpenAI({
     apiKey: env.OPENAI_API_KEY,
+    ...(process.env.OPENAI_BASE_URL ? { baseURL: process.env.OPENAI_BASE_URL } : {}),
     maxRetries: SDK_MAX_RETRIES,
     timeout: SDK_TIMEOUT_MS,
   })


### PR DESCRIPTION
## Why

Alpha deployment needs one OpenAI-compatible provider configuration to apply consistently to both the standalone LingxiGraph Runtime and LingxiLoop's server-side support/triage LLM client.

`docker-compose.mvp.yml` already passed `OPENAI_BASE_URL` to LingxiGraph, and `.env.example` documented it for both sides, but the Node `legacyClient()` ignored the variable and the production MVP compose did not pass it into `lingxiloop`.

## Changes

- `server/src/llm.ts`: use `OPENAI_BASE_URL` as the OpenAI SDK `baseURL` when configured; unchanged default behavior when unset.
- `docker-compose.mvp.yml`: pass `OPENAI_BASE_URL` through to the `lingxiloop` container as well as LingxiGraph.

This is intentionally a narrow release-blocker fix; no runtime boundary, scheduler, action, or cursor semantics change.