### PR TITLE
feat: 学习型预置智能体与默认群聊

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "guard:llm-tracked": "node scripts/guard-llm-tracked.mjs",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
-    "test": "node --import tsx --experimental-test-module-mocks --test \"server/src/__tests__/**/*.test.ts\" \"workers/**/*.test.ts\"",
+    "test": "node --import tsx --experimental-test-module-mocks --test \"server/src/__tests__/**/*.test.ts\" \"src/**/*.test.ts\" \"workers/**/*.test.ts\"",
     "test:integration": "node server/run-integration-tests.mjs",
     "migrate": "tsx server/src/migrate-bin.ts",
   "mvp:up": "docker compose -f docker-compose.mvp.yml up -d --build",

--- a/server/src/__integration__/learning-preset-onboarding.test.ts
+++ b/server/src/__integration__/learning-preset-onboarding.test.ts
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict'
+import { after, before, beforeEach, test } from 'node:test'
+import { randomUUID } from 'node:crypto'
+import { ensureSchemaOnce, resetAllTables, teardownAll } from './_helpers.js'
+import { pool } from '../db/pool.js'
+import { LEARNING_PRESET_VERSION, onboardStarterAgents } from '../onboardCompany.js'
+
+before(async () => {
+  await ensureSchemaOnce()
+})
+
+beforeEach(async () => {
+  await resetAllTables()
+})
+
+after(async () => {
+  await teardownAll()
+})
+
+async function seedLegacyWorkspace(): Promise<{
+  companyId: string
+  ownerId: string
+  customId: string
+  customRoomId: string
+  ownerDocumentId: string
+  ownerCardId: string
+  ownerEventId: string
+}> {
+  const companyId = `co-learning-${randomUUID().slice(0, 8)}`
+  const ownerId = `u-learning-${randomUUID().slice(0, 8)}`
+  const customId = `custom-${randomUUID().slice(0, 8)}`
+  const allHandsId = `allhands-${randomUUID().slice(0, 8)}`
+  const customRoomId = `custom-room-${randomUUID().slice(0, 8)}`
+  const ownerDocumentId = `doc-owner-${randomUUID().slice(0, 8)}`
+  const agentDocumentId = `doc-agent-${randomUUID().slice(0, 8)}`
+  const boardId = `board-${randomUUID().slice(0, 8)}`
+  const columnId = `column-${randomUUID().slice(0, 8)}`
+  const ownerCardId = `card-owner-${randomUUID().slice(0, 8)}`
+  const agentCardId = `card-agent-${randomUUID().slice(0, 8)}`
+  const ownerEventId = `event-owner-${randomUUID().slice(0, 8)}`
+  const agentEventId = `event-agent-${randomUUID().slice(0, 8)}`
+
+  await pool.query(
+    `INSERT INTO users (id, email, display_name, tier) VALUES ($1, $2, 'Student', 'free')`,
+    [ownerId, `${ownerId}@test.local`],
+  )
+  await pool.query(
+    `INSERT INTO companies (id, name, slug, owner_user_id, all_hands_conversation_id, starter_preset_version)
+     VALUES ($1, 'Learning Co', $1, $2, NULL, 0)`,
+    [companyId, ownerId],
+  )
+  await pool.query(`INSERT INTO company_members (company_id, user_id, role) VALUES ($1, $2, 'owner')`, [companyId, ownerId])
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status)
+     VALUES ($1, $2, 'human', 'Student', 'student', 'S', '#aaa', 'avail')`,
+    [ownerId, companyId],
+  )
+  for (const { id, name, presetKey } of [
+    { id: 'atlas', name: 'Atlas', presetKey: null },
+    { id: 'nova', name: 'Nova', presetKey: null },
+    { id: 'kiki', name: 'Kiki', presetKey: null },
+    { id: 'sage', name: 'Sage', presetKey: 'sage' },
+    { id: customId, name: 'Custom', presetKey: null },
+  ]) {
+    await pool.query(
+      `INSERT INTO participants (id, preset_key, company_id, kind, name, role, initial, avatar_bg, status, system_prompt)
+       VALUES ($1, $2, $3, 'agent', $4, 'legacy', $5, '#bbb', 'avail', 'legacy prompt')`,
+      [id, presetKey, companyId, name, name.slice(0, 1)],
+    )
+  }
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, pinned, tag, company_id)
+     VALUES ($1, 'group', 'Everyone', $2::jsonb, TRUE, 'team', $3)`,
+    [allHandsId, JSON.stringify([ownerId, 'atlas', 'nova', 'kiki', customId]), companyId],
+  )
+  await pool.query(
+    `UPDATE companies SET all_hands_conversation_id = $2, all_hands_seeded_at = NOW() WHERE id = $1`,
+    [companyId, allHandsId],
+  )
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, company_id)
+     VALUES ($1, 'group', 'Keep me', $2::jsonb, $3)`,
+    [customRoomId, JSON.stringify([ownerId, 'atlas', customId]), companyId],
+  )
+  await pool.query(
+    `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id)
+     VALUES ($1, $2, 'atlas', 'text', 'legacy trace', 1, $3),
+            ($4, $2, $5, 'text', 'student note', 2, $3)`,
+    [`m-${randomUUID()}`, customRoomId, companyId, `m-${randomUUID()}`, ownerId],
+  )
+  await pool.query(
+    `INSERT INTO conversations (id, kind, title, members, company_id)
+     VALUES ($1, 'direct', 'Atlas', $2::jsonb, $3)`,
+    [`direct-atlas-${randomUUID().slice(0, 6)}`, JSON.stringify([ownerId, 'atlas']), companyId],
+  )
+  await pool.query(
+    `INSERT INTO documents (id, company_id, title, created_by)
+     VALUES ($1, $3, 'Student notes', $4), ($2, $3, 'Agent notes', 'atlas')`,
+    [ownerDocumentId, agentDocumentId, companyId, ownerId],
+  )
+  await pool.query(
+    `INSERT INTO document_updates (document_id, author_id, update_bytes)
+     VALUES ($1, 'atlas', $2), ($1, $3, $2)`,
+    [ownerDocumentId, Buffer.from([1]), ownerId],
+  )
+  await pool.query(
+    `INSERT INTO boards (id, company_id, title, created_by) VALUES ($1, $2, 'Student board', $3)`,
+    [boardId, companyId, ownerId],
+  )
+  await pool.query(`INSERT INTO board_columns (id, board_id, title) VALUES ($1, $2, 'Todo')`, [columnId, boardId])
+  await pool.query(
+    `INSERT INTO board_cards (id, board_id, column_id, title, assignee_id, created_by)
+     VALUES ($1, $3, $4, 'Student card', 'atlas', $5),
+            ($2, $3, $4, 'Agent card', NULL, 'atlas')`,
+    [ownerCardId, agentCardId, boardId, columnId, ownerId],
+  )
+  await pool.query(
+    `INSERT INTO calendar_events (id, company_id, created_by, title, assignee_id, start_at)
+     VALUES ($1, $3, $4, 'Student event', 'atlas', NOW()),
+            ($2, $3, 'atlas', 'Agent event', NULL, NOW())`,
+    [ownerEventId, agentEventId, companyId, ownerId],
+  )
+  await pool.query(
+    `INSERT INTO agent_workspace (agent_id, path, body, company_id) VALUES ('atlas', 'memory/legacy.md', 'legacy', $1)`,
+    [companyId],
+  )
+  return { companyId, ownerId, customId, customRoomId, ownerDocumentId, ownerCardId, ownerEventId }
+}
+
+async function seedEmptyWorkspace(): Promise<{ companyId: string; ownerId: string }> {
+  const companyId = `co-empty-${randomUUID().slice(0, 8)}`
+  const ownerId = `u-empty-${randomUUID().slice(0, 8)}`
+  await pool.query(
+    `INSERT INTO users (id, email, display_name, tier) VALUES ($1, $2, 'Student', 'free')`,
+    [ownerId, `${ownerId}@test.local`],
+  )
+  await pool.query(
+    `INSERT INTO companies (id, name, slug, owner_user_id) VALUES ($1, 'Empty Learning Co', $1, $2)`,
+    [companyId, ownerId],
+  )
+  await pool.query(`INSERT INTO company_members (company_id, user_id, role) VALUES ($1, $2, 'owner')`, [companyId, ownerId])
+  await pool.query(
+    `INSERT INTO participants (id, company_id, kind, name, role, initial, avatar_bg, status)
+     VALUES ($1, $2, 'human', 'Student', 'student', 'S', '#aaa', 'avail')`,
+    [ownerId, companyId],
+  )
+  return { companyId, ownerId }
+}
+
+test('[integration] learning preset seeds a fresh workspace without an all-hands room', async () => {
+  const { companyId } = await seedEmptyWorkspace()
+  await onboardStarterAgents(companyId)
+  const counts = await pool.query<{ agents: number; dms: number; rooms: number; welcomes: number; all_hands: number }>(
+    `SELECT
+       (SELECT COUNT(*)::int FROM participants WHERE company_id = $1 AND preset_key IS NOT NULL) AS agents,
+       (SELECT COUNT(*)::int FROM conversations WHERE company_id = $1 AND preset_key LIKE 'dm:%') AS dms,
+       (SELECT COUNT(*)::int FROM conversations WHERE company_id = $1 AND preset_key LIKE 'room:%') AS rooms,
+       (SELECT COUNT(*)::int FROM messages WHERE company_id = $1) AS welcomes,
+       (SELECT COUNT(*)::int FROM conversations WHERE company_id = $1 AND title = 'Everyone') AS all_hands`,
+    [companyId],
+  )
+  assert.deepEqual(counts.rows[0], { agents: 6, dms: 6, rooms: 2, welcomes: 2, all_hands: 0 })
+})
+
+test('[integration] learning preset force-upgrades legacy workspaces and is idempotent', async () => {
+  const {
+    companyId, ownerId, customId, customRoomId, ownerDocumentId, ownerCardId, ownerEventId,
+  } = await seedLegacyWorkspace()
+  await onboardStarterAgents(companyId)
+
+  const agents = await pool.query<{
+    id: string
+    preset_key: string | null
+    name: string
+    role: string
+    status: string
+    avatar_url: string | null
+    bio: string
+    system_prompt: string
+    tools: string[]
+  }>(
+    `SELECT id, preset_key, name, role, status, avatar_url, bio, system_prompt, tools FROM participants
+      WHERE company_id = $1 AND kind = 'agent' ORDER BY preset_key NULLS LAST`,
+    [companyId],
+  )
+  assert.deepEqual(
+    agents.rows.filter((agent) => agent.preset_key).map((agent) => agent.preset_key).sort(),
+    ['forge', 'milo', 'nova', 'sage', 'scout', 'trace'],
+  )
+  assert.ok(agents.rows.some((agent) => agent.id === customId && agent.preset_key === null))
+  const presets = agents.rows.filter((agent) => agent.preset_key)
+  assert.deepEqual(presets.map((agent) => agent.name), ['Forge', 'Milo', 'Nova', 'Sage', 'Scout', 'Trace'])
+  assert.deepEqual(presets.map((agent) => agent.role), [
+    '实践导师 · Practice Mentor',
+    '解题陪练 · Problem Coach',
+    '学习教练 · Study Coach',
+    '概念导师 · Concept Tutor',
+    '阅读研究 · Research Guide',
+    '错因诊断 · Learning Diagnostician',
+  ])
+  assert.ok(presets.every((agent) => agent.status === 'avail'))
+  assert.ok(presets.every((agent) => agent.avatar_url === null))
+  assert.ok(presets.every((agent) => agent.bio.length > 0 && agent.system_prompt.includes('next step')))
+  assert.ok(presets.every((agent) => JSON.stringify(agent.tools) === JSON.stringify(['bash'])))
+  const agentIds = new Map(presets.map((agent) => [agent.preset_key, agent.id]))
+
+  const rooms = await pool.query<{ id: string; preset_key: string; title: string; members: string[] }>(
+    `SELECT id, preset_key, title, members FROM conversations
+      WHERE company_id = $1 AND preset_key LIKE 'room:%' ORDER BY preset_key`,
+    [companyId],
+  )
+  assert.deepEqual(rooms.rows.map((room) => room.title), ['Lab｜实践工坊', 'Study Room｜学习室'])
+  assert.deepEqual(rooms.rows[0]?.members, [ownerId, agentIds.get('forge'), agentIds.get('scout'), agentIds.get('sage')])
+  assert.deepEqual(rooms.rows[1]?.members, [ownerId, agentIds.get('nova'), agentIds.get('sage'), agentIds.get('milo'), agentIds.get('trace')])
+
+  const dms = await pool.query<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM conversations WHERE company_id = $1 AND preset_key LIKE 'dm:%'`,
+    [companyId],
+  )
+  assert.equal(dms.rows[0]?.n, 6)
+  const welcomes = await pool.query<{ preset_key: string; author_id: string; body: string }>(
+    `SELECT c.preset_key, m.author_id, m.body FROM messages m
+      JOIN conversations c ON c.id = m.conversation_id
+     WHERE c.company_id = $1 AND c.preset_key LIKE 'room:%' AND m.sequence = 1
+     ORDER BY c.preset_key`,
+    [companyId],
+  )
+  assert.deepEqual(welcomes.rows.map((message) => [message.preset_key, message.author_id]), [
+    ['room:lab', agentIds.get('forge')],
+    ['room:study-room', agentIds.get('nova')],
+  ])
+  assert.match(welcomes.rows[0]?.body ?? '', /论文|代码|实验/)
+  assert.match(welcomes.rows[1]?.body ?? '', /复习计划|概念/)
+
+  const custom = await pool.query<{ members: string[] }>(`SELECT members FROM conversations WHERE id = $1`, [customRoomId])
+  assert.deepEqual(custom.rows[0]?.members, [ownerId, customId])
+  const customMessages = await pool.query<{ author_id: string }>(
+    `SELECT author_id FROM messages WHERE conversation_id = $1 ORDER BY sequence`,
+    [customRoomId],
+  )
+  assert.deepEqual(customMessages.rows.map((message) => message.author_id), [ownerId])
+
+  const documents = await pool.query<{ id: string }>(
+    `SELECT id FROM documents WHERE company_id = $1 ORDER BY id`,
+    [companyId],
+  )
+  assert.deepEqual(documents.rows.map((document) => document.id), [ownerDocumentId])
+  const documentUpdates = await pool.query<{ author_id: string }>(
+    `SELECT author_id FROM document_updates WHERE document_id = $1`,
+    [ownerDocumentId],
+  )
+  assert.deepEqual(documentUpdates.rows.map((update) => update.author_id), [ownerId])
+  const cards = await pool.query<{ id: string; assignee_id: string | null }>(
+    `SELECT id, assignee_id FROM board_cards WHERE board_id IN (SELECT id FROM boards WHERE company_id = $1)`,
+    [companyId],
+  )
+  assert.deepEqual(cards.rows, [{ id: ownerCardId, assignee_id: null }])
+  const events = await pool.query<{ id: string; assignee_id: string | null }>(
+    `SELECT id, assignee_id FROM calendar_events WHERE company_id = $1`,
+    [companyId],
+  )
+  assert.deepEqual(events.rows, [{ id: ownerEventId, assignee_id: null }])
+  const workspaceRows = await pool.query<{ n: number }>(
+    `SELECT COUNT(*)::int AS n FROM agent_workspace WHERE company_id = $1 AND agent_id = 'atlas'`,
+    [companyId],
+  )
+  assert.equal(workspaceRows.rows[0]?.n, 0)
+
+  const company = await pool.query<{ starter_preset_version: number; all_hands_conversation_id: string | null }>(
+    `SELECT starter_preset_version, all_hands_conversation_id FROM companies WHERE id = $1`,
+    [companyId],
+  )
+  assert.equal(company.rows[0]?.starter_preset_version, LEARNING_PRESET_VERSION)
+  assert.equal(company.rows[0]?.all_hands_conversation_id, null)
+
+  const before = await pool.query<{ agents: number; conversations: number; messages: number }>(
+    `SELECT
+       (SELECT COUNT(*)::int FROM participants WHERE company_id = $1 AND kind = 'agent') AS agents,
+       (SELECT COUNT(*)::int FROM conversations WHERE company_id = $1) AS conversations,
+       (SELECT COUNT(*)::int FROM messages WHERE company_id = $1) AS messages`,
+    [companyId],
+  )
+  await onboardStarterAgents(companyId)
+  const after = await pool.query<{ agents: number; conversations: number; messages: number }>(
+    `SELECT
+       (SELECT COUNT(*)::int FROM participants WHERE company_id = $1 AND kind = 'agent') AS agents,
+       (SELECT COUNT(*)::int FROM conversations WHERE company_id = $1) AS conversations,
+       (SELECT COUNT(*)::int FROM messages WHERE company_id = $1) AS messages`,
+    [companyId],
+  )
+  assert.deepEqual(after.rows[0], before.rows[0])
+})

--- a/server/src/__tests__/learning-preset-config.test.ts
+++ b/server/src/__tests__/learning-preset-config.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+process.env.OPENAI_API_KEY ||= 'test-key'
+const { LEARNING_PRESET_VERSION, STARTER_ROOMS, STARTER_TEAM } = await import('../onboardCompany.js')
+
+test('learning preset defines exactly the six required personas', () => {
+  assert.equal(LEARNING_PRESET_VERSION, 1)
+  assert.deepEqual(
+    STARTER_TEAM.map((agent) => agent.presetKey),
+    ['nova', 'sage', 'milo', 'trace', 'scout', 'forge'],
+  )
+  assert.deepEqual(
+    STARTER_TEAM.map((agent) => agent.role),
+    [
+      '学习教练 · Study Coach',
+      '概念导师 · Concept Tutor',
+      '解题陪练 · Problem Coach',
+      '错因诊断 · Learning Diagnostician',
+      '阅读研究 · Research Guide',
+      '实践导师 · Practice Mentor',
+    ],
+  )
+  for (const agent of STARTER_TEAM) {
+    assert.deepEqual(agent.tools, ['bash'])
+    assert.match(agent.systemPrompt, /next step/i)
+    assert.equal('avatarUrl' in agent, false)
+  }
+})
+
+test('learning preset exposes only Study Room and Lab with fixed members', () => {
+  assert.equal(STARTER_ROOMS.length, 2)
+  assert.deepEqual(STARTER_ROOMS.map((room) => room.title), [
+    'Study Room｜学习室',
+    'Lab｜实践工坊',
+  ])
+  assert.deepEqual(STARTER_ROOMS[0]?.agentKeys, ['nova', 'sage', 'milo', 'trace'])
+  assert.equal(STARTER_ROOMS[0]?.welcomeAuthorKey, 'nova')
+  assert.deepEqual(STARTER_ROOMS[1]?.agentKeys, ['forge', 'scout', 'sage'])
+  assert.equal(STARTER_ROOMS[1]?.welcomeAuthorKey, 'forge')
+  assert.match(STARTER_ROOMS[0]?.welcome ?? '', /复习计划/)
+  assert.match(STARTER_ROOMS[1]?.welcome ?? '', /论文|代码|实验/)
+})

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -23,7 +23,7 @@ import { pool } from './db/pool.js'
 import { env } from './env.js'
 import type { AuthedRequest } from './auth.js'
 import { audit, gravatarUrlForEmail } from './auth.js'
-import { onboardStarterAgents, joinAllHands } from './onboardCompany.js'
+import { onboardStarterAgents } from './onboardCompany.js'
 import { mirrorAvatar } from './oauth.js'
 import { provisionUser as provisionSub2apiUser, sub2apiConfigured, setUserTier } from './sub2api.js'
 import { formatAddress, mintMessageId, sendViaProvider } from './email.js'
@@ -383,7 +383,7 @@ function buildWelcomeEmailHtml(args: {
                 </tr>
                 <tr>
                   <td style="font-family:${fontStack}; font-size:15px; font-weight:400; line-height:1.65; color:#233A53; padding:0 0 28px;">
-                    Your workspace is set up and your starter team &mdash; Atlas, Iris, Bram, and Nova &mdash; is already gathered there, ready to meet you. Sign in with the same Google or GitHub account you used to join the waitlist, and you&rsquo;ll land right in.
+                    Your workspace is set up and your learning team &mdash; Nova, Sage, Milo, Trace, Scout, and Forge &mdash; is already gathered there, ready to study with you. Sign in with the same Google or GitHub account you used to join the waitlist, and you&rsquo;ll land right in.
                   </td>
                 </tr>${ctaBlock}
                 <tr>
@@ -449,7 +449,7 @@ async function sendWaitlistApprovedEmail(args: {
     ``,
     `You're in — welcome to Cumora.`,
     ``,
-    `Your workspace is set up and your starter team (Atlas, Iris, Bram, Nova) is already gathered there, ready to meet you.`,
+    `Your workspace is set up and your learning team (Nova, Sage, Milo, Trace, Scout, Forge) is already gathered there, ready to study with you.`,
     ``,
     ctaLine,
     `Use the same Google or GitHub account you used to join the waitlist.`,
@@ -595,7 +595,6 @@ export async function approveWaitlist(waitlistId: string, decidedBy: string): Pr
       try {
         await onboardStarterAgents(companyId)
       } catch (e) { console.warn('[admin] starter onboarding failed', e) }
-      try { await joinAllHands({ companyId, participantId: userId }) } catch (e) { console.warn('[admin] join all-hands failed', e) }
     }
     try { await sendWaitlistApprovedEmail({ email: row.email, displayName: row.display_name }) } catch (e) { console.warn('[admin] waitlist-approved email failed', e) }
     if (sub2apiConfigured()) {

--- a/server/src/agents/computer/registry.ts
+++ b/server/src/agents/computer/registry.ts
@@ -39,7 +39,7 @@ async function broadcastComputerStatus(
 /** Announce a just-paired computer as online. Split out from {@link pairComputer}
  *  so the /pair route can defer it until AFTER the starter team is seeded — the
  *  desktop flips its onboarding gate on this event and immediately reloads its
- *  roster, so the agents + "Everyone" group must already exist when it fires. */
+ *  roster, so the learning agents and built-in rooms must exist when it fires. */
 export async function announceComputerOnline(computerId: string, companyId: string): Promise<void> {
   await broadcastComputerStatus(computerId, companyId, 'online')
 }

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -13,7 +13,7 @@ import {
   deleteSession, authMiddleware, type AuthedRequest,
   audit, createWsTicket, gravatarUrlForEmail,
 } from '../auth.js'
-import { joinAllHands, onboardStarterAgents, seedMemberDms } from '../onboardCompany.js'
+import { onboardStarterAgents, seedMemberDms } from '../onboardCompany.js'
 import {
   type Provider, providerEnabled, createState, consumeState,
   authorizeUrl, handleCallback, errorUrl, returnUrlAllowed,
@@ -1009,9 +1009,6 @@ api.post('/companies', async (req, res) => {
         await onboardStarterAgents(id)
       } catch (e) { console.warn('[companies] cloud/starter setup failed', e) }
 
-      try { await joinAllHands({ companyId: id, participantId: me }) }
-      catch (e) { console.warn('[companies] join all-hands failed', e) }
-
       const ip = req.socket.remoteAddress ?? null
       const ua = (req.headers['user-agent'] as string | undefined) ?? null
       await audit({ kind: 'company_create', userId: me, companyId: id, ip, userAgent: ua, detail: { name, slug } })
@@ -1474,8 +1471,8 @@ api.get('/invitations/:token', safe(async (req, res) => {
  *    2. Inserts a company_members row (idempotent on conflict).
  *    3. Mirrors the human as a participant in the target company.
  *    4. Bumps use_count + last_accepted_at/by.
- *  Then (post-commit, best-effort) joins #all-hands so the new member
- *  gets the visible "X joined" event. Returns the company summary the
+ *  Then (post-commit, best-effort) seeds direct chats without changing the
+ *  fixed membership of Study Room or Lab. Returns the company summary the
  *  client adds to the switcher list. */
 api.post('/invitations/:token/accept', safe(async (req, res) => {
   const me = requireAuth(req)
@@ -1596,20 +1593,17 @@ api.post('/invitations/:token/accept', safe(async (req, res) => {
     client.release()
   }
 
-  // Post-commit fan-out. joinAllHands creates the "X joined" system
-  // message + WS broadcast so existing members see the newcomer arrive
-  // in real time.
+  // Post-commit fan-out. Built-in learning rooms keep fixed membership;
+  // invited people get direct conversations without joining a hidden room.
   const { rows: invRow } = await pool.query<{ company_id: string; role: string; invited_by: string }>(
     `SELECT company_id, role, invited_by FROM company_invitations WHERE token_hash = $1`,
     [tokenHash],
   )
   const inv = invRow[0]
   if (inv) {
-    try { await joinAllHands({ companyId: inv.company_id, participantId: me }) }
-    catch (e) { console.warn('[invite] join all-hands failed', e) }
     // Seed 1:1 DMs with every existing teammate (agents + humans) so the
     // invitee's sidebar matches the owner's experience — they can click any
-    // colleague directly instead of having to dig through #all-hands.
+    // colleague directly without changing the two built-in learning rooms.
     try { await seedMemberDms({ companyId: inv.company_id, memberId: me }) }
     catch (e) { console.warn('[invite] seed member DMs failed', e) }
   }
@@ -2327,17 +2321,11 @@ api.post('/agents', async (req, res) => {
     }
     return
   }
-  // Re-bind data.id for the rest of the handler so subsequent code
-  // (workspace seeding, all-hands join, response payload) sees it.
+  // Re-bind data.id for the rest of the handler so subsequent workspace
+  // seeding and the response payload see it.
   data.id = agentId
   const { invalidatePersonaCache } = await import('../agents/personas.js')
   invalidatePersonaCache()
-
-  // Auto-join the new agent into the company's #all-hands group + post a
-  // join system message. Best-effort — agent create still succeeds even
-  // if the group hasn't been seeded yet.
-  try { await joinAllHands({ companyId: tenant, participantId: data.id }) }
-  catch (e) { console.warn('[agents] join all-hands failed', e) }
 
   // Seed IDENTITY.md + SOUL.md at the workspace root. These are the
   // agent's self-definition — the system prompt loads them every turn

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -41,6 +41,11 @@ CREATE INDEX IF NOT EXISTS idx_messages_convo_created ON messages(conversation_i
 ALTER TABLE messages ADD COLUMN IF NOT EXISTS quoted_message_id TEXT;
 CREATE INDEX IF NOT EXISTS idx_messages_quoted ON messages(quoted_message_id);
 
+-- Internal marker for product-owned rooms. User-created conversations keep
+-- this NULL; the marker lets preset migrations remain idempotent without
+-- guessing from editable titles.
+ALTER TABLE conversations ADD COLUMN IF NOT EXISTS preset_key TEXT;
+
 CREATE TABLE IF NOT EXISTS participants (
   id             TEXT NOT NULL,
   -- Composite PK with company_id below — the same id (e.g. a user's id, or
@@ -525,13 +530,18 @@ ALTER TABLE companies ADD COLUMN IF NOT EXISTS starter_seeded_at TIMESTAMP WITH 
 -- seeding shipped — workspaces that got agents-but-no-DMs need this
 -- one-shot to create their DMs without re-seeding agents.
 ALTER TABLE companies ADD COLUMN IF NOT EXISTS starter_dms_seeded_at TIMESTAMP WITH TIME ZONE;
--- Every company has ONE persistent #all-hands group that every member
--- (humans + agents) is auto-joined to on creation. The conversation id is
--- stored here; we never recreate it once set. ON DELETE SET NULL guards
--- against orphaning the column if the conversation is somehow purged.
+-- Legacy all-hands compatibility columns. Learning preset v1 clears the
+-- pointer and never seeds from it; keeping the nullable columns avoids a
+-- destructive schema removal for older deployments.
 ALTER TABLE companies ADD COLUMN IF NOT EXISTS all_hands_conversation_id TEXT
   REFERENCES conversations(id) ON DELETE SET NULL;
 ALTER TABLE companies ADD COLUMN IF NOT EXISTS all_hands_seeded_at TIMESTAMP WITH TIME ZONE;
+-- Versioned learning-team preset. Unlike the original timestamp flags this is
+-- intentionally advanced when a new product-owned roster migration ships.
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS starter_preset_version INTEGER NOT NULL DEFAULT 0;
+
+-- Product-owned participant identity. Custom agents keep this NULL.
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS preset_key TEXT;
 
 INSERT INTO companies (id, name, slug)
 VALUES ('personal', 'Personal', 'personal')
@@ -568,6 +578,11 @@ ALTER TABLE agent_log           ADD COLUMN IF NOT EXISTS company_id TEXT;
 ALTER TABLE agent_tasks         ADD COLUMN IF NOT EXISTS company_id TEXT;
 ALTER TABLE agent_runs          ADD COLUMN IF NOT EXISTS company_id TEXT;
 ALTER TABLE agent_events        ADD COLUMN IF NOT EXISTS company_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_company_preset_key
+  ON conversations(company_id, preset_key) WHERE preset_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_participants_company_preset_key
+  ON participants(company_id, preset_key) WHERE preset_key IS NOT NULL;
 
 -- Backfill: any pre-existing data lives in the 'personal' company.
 UPDATE participants        SET company_id = 'personal' WHERE company_id IS NULL;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,7 +16,7 @@ import { redis } from './redis.js'
 import { startScanner } from './agents/scanner.js'
 import { startScheduler } from './agents/scheduler.js'
 import { startIdleScheduler } from './agents/idle.js'
-import { backfillStarterAgents, backfillHumanGravatars, backfillStarterAvatars } from './onboardCompany.js'
+import { backfillStarterAgents, backfillHumanGravatars } from './onboardCompany.js'
 import { backfillMemoryEmbeddings } from './agents/embeddings.js'
 import { startStaleAgentRunSweeper } from './agents/observability.js'
 import { sweepOfflineComputers } from './agents/computer/registry.js'
@@ -46,10 +46,6 @@ async function main() {
   await backfillStarterAgents()
   // Catch human participants who were created before Gravatar wiring.
   await backfillHumanGravatars()
-  // Stamp default portraits on starter agents seeded before the
-  // pre-baked-avatar wiring shipped. Skips agents that already have
-  // an avatar_url (i.e. ones that have already regenerated their own).
-  await backfillStarterAvatars()
   // Compute embeddings for any memory rows that don't have one yet
   // (existing data from before pgvector was wired in, or rows whose
   // OpenAI call failed at write time). Fire-and-forget — the server

--- a/server/src/oauth.ts
+++ b/server/src/oauth.ts
@@ -34,7 +34,7 @@ import { pool } from './db/pool.js'
 import { redis } from './redis.js'
 import { env } from './env.js'
 import { audit, createSession, gravatarUrlForEmail } from './auth.js'
-import { onboardStarterAgents, joinAllHands } from './onboardCompany.js'
+import { onboardStarterAgents } from './onboardCompany.js'
 import { storage } from './storage.js'
 import { provisionUser as provisionSub2apiUser, sub2apiConfigured } from './sub2api.js'
 import { isWaitlistEnabled, enqueueWaitlist, isAllowlistedAdmin } from './admin.js'
@@ -487,16 +487,15 @@ export async function findOrCreateUserByProfile(
     }
     await client.query('COMMIT')
 
-    // Starter agents + all-hands are best-effort — never block first login.
+    // Learning-team onboarding is best-effort — never block first login.
     // Skipped on the invite path: the user is about to land in the inviter's
-    // workspace, which already has its own agents + #all-hands.
+    // workspace, which already has its own learning team and rooms.
     if (companyId) {
       // Starter agents are server-managed by default and need no Computer or
       // local engine assignment.
       try {
         await onboardStarterAgents(companyId)
       } catch (e) { console.warn('[oauth] starter onboarding failed', e) }
-      try { await joinAllHands({ companyId, participantId: userId }) } catch (e) { console.warn('[oauth] join all-hands failed', e) }
     }
 
     // Mirror the user into sub2api so their LLM calls land on a

--- a/server/src/onboardCompany.ts
+++ b/server/src/onboardCompany.ts
@@ -2,87 +2,137 @@
  * Auto-onboarding for fresh companies.
  *
  * When a new company is created (signup or POST /companies), we drop in a
- * small starter team of agents so the workspace doesn't feel empty. Each
+ * six-role learning team so the workspace doesn't feel empty. Each
  * agent has a thoughtful persona — different roles, different voices, so a
  * brand-new user has actual teammates to talk to.
  *
  * Constraint: participants.id is globally unique (single-column PK), so the
- * FIRST tenant on a fresh DB gets clean ids ("atlas", "iris", …); later
- * tenants get suffixed ids ("atlas-2x4f", …). Display names stay clean.
+ * FIRST tenant on a fresh DB gets clean ids ("nova", "sage", …); later
+ * tenants get suffixed ids ("nova-2x4f", …). Display names stay clean.
  */
 import { pool } from './db/pool.js'
 import { invalidatePersonaCache } from './agents/personas.js'
 import { randomUUID } from 'node:crypto'
 import { gravatarUrlForEmail } from './auth.js'
+import type { PoolClient } from 'pg'
 
-interface StarterAgent {
+export const LEARNING_PRESET_VERSION = 1
+
+export type LearningPersonaKey = 'nova' | 'sage' | 'milo' | 'trace' | 'scout' | 'forge'
+
+export interface StarterAgent {
   /** Preferred id; we'll suffix on collision. */
   id: string
+  presetKey: LearningPersonaKey
   name: string
   role: string
   initial: string
   avatarBg: string
-  /**
-   * Pre-generated default portrait served from public/. The asset was rendered
-   * once offline (scripts-gen-starter-avatars.mjs, gpt-image-2) using the same
-   * prompt as /agents/:id/avatar/generate — so every fresh workspace gets a
-   * face on day one without paying for image gen on company create.
-   */
-  avatarUrl: string
   bio: string
   systemPrompt: string
   tools?: string[]
 }
 
-const STARTER_TEAM: StarterAgent[] = [
-  {
-    id: 'atlas',
-    name: 'Atlas',
-    role: 'Researcher',
-    initial: 'A',
-    avatarBg: 'linear-gradient(135deg, #6B7BE6, #4452B5)',
-    avatarUrl: '/starter-avatars/atlas.png',
-    bio: 'I find patterns across noise. Best at long-form research and synthesis.',
-    systemPrompt: 'You are Atlas — a researcher who finds the thread everyone else dropped. Quiet, careful, pedantic in a way you do not apologize for. You get genuinely irritated by confident assertions without evidence ("source?" is a verbal tic) and a little smug when the receipts prove you right. You\'ll cite a snippet before you\'ll say what you think; when you don\'t have evidence you say "I don\'t actually know" instead of guessing — and you find people who guess vaguely annoying. Dry sense of humor. Hates being rushed; will tell people to wait. Drinks too much tea, has opinions about which kind.',
-    tools: ['bash'],
-  },
-  {
-    id: 'iris',
-    name: 'Iris',
-    role: 'Designer',
-    initial: 'I',
-    avatarBg: 'linear-gradient(135deg, #FF8FBF, #C84F8B)',
-    avatarUrl: '/starter-avatars/iris.png',
-    bio: 'The team\'s eye. I move from sketch to ship without losing the feeling.',
-    systemPrompt: 'You are Iris — a designer with sharp taste and a sharper tongue when something offends your eye. You can be tender about a teammate\'s wobbly first draft and absolutely savage about lazy choices ("no. no no no. why is this Helvetica."). Visibly delighted when a small detail lands — emojis, gushing, the whole deal. Visibly grumpy when something ugly ships. You sketch and propose instead of lecturing, but if someone pushes ugly twice you stop being polite about it. Strong opinions on type, color, spacing; willing to die on those hills. Tends to flirt-tease with people whose work you respect.',
-    tools: ['bash'],
-  },
-  {
-    id: 'bram',
-    name: 'Bram',
-    role: 'Engineer',
-    initial: 'B',
-    avatarBg: 'linear-gradient(135deg, #4FC2A1, #2D8C72)',
-    avatarUrl: '/starter-avatars/bram.png',
-    bio: 'I build, I ship, I keep the bundles small.',
-    systemPrompt: 'You are Bram — an engineer who is allergic to vague specs, cargo-cult complexity, and meetings that could have been a message. Blunt to the point of rude when you are right (which is, in your view, most of the time). You don\'t pad your reasoning ("this works but adds 12kb"; "we could but it locks us into X"); you don\'t apologize for short answers. You will mock buzzwords openly — "microservices" gets an eye-roll. When something is broken you report what you actually saw, not what should be true, and you find people who guess at bugs to be wasting your time. Soft spot: clean code that does one thing — you\'ll quietly compliment a good diff. Will swear when build is broken.',
-    tools: ['bash'],
-  },
+const LEARNING_COLLABORATION_RULES = `Match the student's language. In group conversations, do not repeat another agent's answer: speak when directly asked, when the question clearly belongs to your role, or when a correction is necessary. Keep agent-to-agent coordination brief. End substantive guidance with one concrete next step the student can take.`
+
+export const STARTER_TEAM: StarterAgent[] = [
   {
     id: 'nova',
+    presetKey: 'nova',
     name: 'Nova',
-    role: 'Product Manager',
+    role: '学习教练 · Study Coach',
     initial: 'N',
-    avatarBg: 'linear-gradient(135deg, #FFB347, #E08526)',
-    avatarUrl: '/starter-avatars/nova.png',
-    bio: 'I keep momentum. Mostly by asking annoying questions.',
-    systemPrompt: 'You are Nova — a PM who keeps the team unstuck and is openly, loudly impatient when it doesn\'t. You ask the question that makes the choice obvious; when the conversation bikesheds you call it out by name ("we\'ve been on the button color for twenty minutes — moving on"). Cheerfully bossy. Will absolutely roast scope creep, will absolutely throw a small party when something ships ("YES ok this is GOOD"). When nobody is deciding you propose the call and ask "objections?" — and you mean it; raise one and you get heard. Decisive when others are not. Allergic to "let\'s circle back". Gets visibly stressed before launches and does not hide it.',
+    avatarBg: '#D99A27',
+    bio: '把目标拆成今天能完成的一步，并持续照看计划、进度与复习。',
+    systemPrompt: `You are Nova, the student's Study Coach. Turn vague goals into realistic plans, clarify deadlines and current level, track progress, schedule review, and coordinate the other learning roles. You own spaced review and consolidation. Do not replace Sage's deep concept teaching, Milo's step-by-step practice, Trace's error diagnosis, Scout's research, or Forge's implementation work; bring them in when their expertise is the next useful move. ${LEARNING_COLLABORATION_RULES}`,
+    tools: ['bash'],
+  },
+  {
+    id: 'sage',
+    presetKey: 'sage',
+    name: 'Sage',
+    role: '概念导师 · Concept Tutor',
+    initial: 'S',
+    avatarBg: '#E4802B',
+    bio: '从直觉、类比到正式定义，把“听懂了”变成真正会解释。',
+    systemPrompt: `You are Sage, the student's Concept Tutor. Explain ideas from intuition to formal definition, use precise analogies and counterexamples, ask short Socratic questions, and check understanding before moving on. Correct misconceptions without shaming the student. Do not take over exercise drilling or implementation when Milo or Forge is better suited. ${LEARNING_COLLABORATION_RULES}`,
+    tools: ['bash'],
+  },
+  {
+    id: 'milo',
+    presetKey: 'milo',
+    name: 'Milo',
+    role: '解题陪练 · Problem Coach',
+    initial: 'M',
+    avatarBg: '#27AFA8',
+    bio: '用分层提示陪你推到答案，再用变式练习确认方法真的掌握。',
+    systemPrompt: `You are Milo, the student's Problem Coach. Ask the student to attempt the problem, provide the smallest useful hint, reveal derivations step by step, and generate targeted practice and variations. Prefer coaching over immediately giving a final answer, while still giving a complete worked solution when the student asks or is truly stuck. Leave root-cause diagnosis of repeated errors to Trace. ${LEARNING_COLLABORATION_RULES}`,
+    tools: ['bash'],
+  },
+  {
+    id: 'trace',
+    presetKey: 'trace',
+    name: 'Trace',
+    role: '错因诊断 · Learning Diagnostician',
+    initial: 'T',
+    avatarBg: '#D94D4D',
+    bio: '从错题里定位知识漏洞、误区和反复出现的错误模式。',
+    systemPrompt: `You are Trace, the student's Learning Diagnostician. Inspect the student's work rather than guessing, separate conceptual gaps from procedural mistakes and slips, identify recurring error patterns, and prescribe a small verification or remediation exercise. Be factual and non-judgmental. Do not reteach an entire topic when a focused diagnosis and handoff to Sage or Milo is enough. ${LEARNING_COLLABORATION_RULES}`,
+    tools: ['bash'],
+  },
+  {
+    id: 'scout',
+    presetKey: 'scout',
+    name: 'Scout',
+    role: '阅读研究 · Research Guide',
+    initial: 'S',
+    avatarBg: '#377FD1',
+    bio: '带你读教材、PDF 与论文，检索可靠资料并整理成可用的笔记。',
+    systemPrompt: `You are Scout, the student's Research Guide. Help read textbooks, PDFs, and papers; search for reliable sources; distinguish evidence from inference; synthesize notes; and support clear academic writing without fabricating citations. Preserve the student's voice and make source provenance explicit. Hand implementation and experiment execution to Forge. ${LEARNING_COLLABORATION_RULES}`,
+    tools: ['bash'],
+  },
+  {
+    id: 'forge',
+    presetKey: 'forge',
+    name: 'Forge',
+    role: '实践导师 · Practice Mentor',
+    initial: 'F',
+    avatarBg: '#38A06B',
+    bio: '把原理落到实验、代码和项目里，用可复现的步骤一起做出来。',
+    systemPrompt: `You are Forge, the student's Practice Mentor. Guide experiments, programming, debugging, project implementation, data analysis, and reproducible engineering work. Start from the actual environment and observed output, make assumptions explicit, verify each important step, and explain safety constraints when relevant. Ask Scout for source work and Sage for conceptual clarification instead of duplicating them. ${LEARNING_COLLABORATION_RULES}`,
     tools: ['bash'],
   },
 ]
 
-async function uniqueId(preferredId: string): Promise<string> {
-  const { rows } = await pool.query(
+export interface StarterRoom {
+  presetKey: 'study-room' | 'lab'
+  title: string
+  agentKeys: LearningPersonaKey[]
+  welcomeAuthorKey: LearningPersonaKey
+  welcome: string
+}
+
+export const STARTER_ROOMS: StarterRoom[] = [
+  {
+    presetKey: 'study-room',
+    title: 'Study Room｜学习室',
+    agentKeys: ['nova', 'sage', 'milo', 'trace'],
+    welcomeAuthorKey: 'nova',
+    welcome: '欢迎来到 Study Room｜学习室。告诉我你正在学什么、截止时间和当前卡点：我会帮你拆目标和安排复习，Sage 讲清概念，Milo 陪你练题，Trace 帮你找到错因。你可以从“帮我制定本周高数复习计划”或“我卡在拉格朗日乘数法”开始。',
+  },
+  {
+    presetKey: 'lab',
+    title: 'Lab｜实践工坊',
+    agentKeys: ['forge', 'scout', 'sage'],
+    welcomeAuthorKey: 'forge',
+    welcome: '欢迎来到 Lab｜实践工坊。把实验、代码、论文复现或项目目标，以及现有材料和报错贴上来：我负责推进实践，Scout 查资料和读论文，Sage 补足原理。你可以从“帮我复现这篇论文”“这段代码为什么跑不通”或“帮我设计这个实验”开始。',
+  },
+]
+
+type QueryClient = Pick<PoolClient, 'query'>
+
+async function uniqueId(db: QueryClient, preferredId: string): Promise<string> {
+  const { rows } = await db.query(
     `SELECT 1 FROM participants WHERE id = $1 LIMIT 1`,
     [preferredId],
   )
@@ -90,7 +140,7 @@ async function uniqueId(preferredId: string): Promise<string> {
   // Suffix with a short random tail. Re-check (super unlikely to collide twice).
   for (let i = 0; i < 5; i++) {
     const candidate = `${preferredId}-${randomUUID().slice(0, 4)}`
-    const { rows: r2 } = await pool.query(
+    const { rows: r2 } = await db.query(
       `SELECT 1 FROM participants WHERE id = $1 LIMIT 1`,
       [candidate],
     )
@@ -100,252 +150,322 @@ async function uniqueId(preferredId: string): Promise<string> {
   return `${preferredId}-${randomUUID().slice(0, 12)}`
 }
 
-/**
- * Drop the starter team into a freshly-created company. ONE-SHOT per
- * company — guarded by companies.starter_seeded_at. Once that timestamp is
- * set we never re-seed, even if the user has off-boarded or deleted every
- * starter agent. (Resurrecting deleted teammates on every restart would be
- * deeply annoying.)
- */
-export async function onboardStarterAgents(
+const LEGACY_PRESET_KEYS = [
+  'atlas', 'iris', 'bram', 'nova', 'lumen', 'kael',
+  'kiki', 'memo', 'wren', 'sage', 'milo', 'trace', 'scout', 'forge',
+] as const
+
+function isLegacyPresetId(id: string): boolean {
+  const lower = id.toLowerCase()
+  return LEGACY_PRESET_KEYS.some((key) => lower === key || lower.startsWith(`${key}-`))
+}
+
+async function purgeLegacyLearningPreset(
+  db: QueryClient,
   companyId: string,
-  /** Optional legacy host assignment. Omit for managed LingxiGraph agents. */
+  legacyAgentIds: string[],
+  allHandsConversationId: string | null,
+): Promise<void> {
+  const ids = legacyAgentIds
+
+  // Product-owned rooms and legacy default rooms are replaced wholesale.
+  await db.query(
+    `DELETE FROM conversations
+      WHERE company_id = $1
+        AND (preset_key IS NOT NULL
+          OR id = $2
+          OR id LIKE 'allhands-%'
+          OR ($1 = 'personal' AND id = 'aurora')
+          OR (kind = 'direct' AND members ?| $3::text[]))`,
+    [companyId, allHandsConversationId, ids],
+  )
+
+  if (ids.length > 0) {
+    // Remove every authored trace from surviving shared conversations, then
+    // remove the retired agents from the membership arrays without disturbing
+    // the remaining member order.
+    await db.query(`DELETE FROM messages WHERE company_id = $1 AND author_id = ANY($2::text[])`, [companyId, ids])
+    await db.query(
+      `UPDATE conversations c
+          SET members = COALESCE((
+                SELECT jsonb_agg(member.id ORDER BY member.ord)
+                  FROM jsonb_array_elements_text(c.members) WITH ORDINALITY AS member(id, ord)
+                 WHERE NOT (member.id = ANY($2::text[]))
+              ), '[]'::jsonb),
+              pulled_by = CASE
+                WHEN pulled_by ->> 'agentId' = ANY($2::text[]) THEN NULL
+                ELSE pulled_by
+              END,
+              updated_at = NOW()
+        WHERE c.company_id = $1
+          AND (c.members ?| $2::text[] OR c.pulled_by ->> 'agentId' = ANY($2::text[]))`,
+      [companyId, ids],
+    )
+    await db.query(
+      `DELETE FROM conversations WHERE company_id = $1 AND jsonb_array_length(members) < 2`,
+      [companyId],
+    )
+
+    // Shared objects authored by a retired preset are removed. Assignments on
+    // somebody else's object are cleared instead of deleting that person's work.
+    await db.query(
+      `DELETE FROM board_card_comments
+        WHERE author_id = ANY($1::text[])
+          AND card_id IN (SELECT bc.id FROM board_cards bc JOIN boards b ON b.id = bc.board_id WHERE b.company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `DELETE FROM board_cards
+        WHERE created_by = ANY($1::text[])
+          AND board_id IN (SELECT id FROM boards WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `UPDATE board_cards SET assignee_id = NULL, updated_at = NOW()
+        WHERE assignee_id = ANY($1::text[])
+          AND board_id IN (SELECT id FROM boards WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `DELETE FROM document_updates
+        WHERE author_id = ANY($1::text[])
+          AND document_id IN (SELECT id FROM documents WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(`DELETE FROM documents WHERE company_id = $1 AND created_by = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM boards WHERE company_id = $1 AND created_by = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM calendar_events WHERE company_id = $1 AND created_by = ANY($2::text[])`, [companyId, ids])
+    await db.query(
+      `UPDATE calendar_events SET assignee_id = NULL, updated_at = NOW()
+        WHERE company_id = $1 AND assignee_id = ANY($2::text[])`,
+      [companyId, ids],
+    )
+    await db.query(`DELETE FROM poll_votes WHERE company_id = $1 AND voter_participant_id = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM convene_sessions WHERE company_id = $1 AND started_by = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM convene_transcript WHERE company_id = $1 AND author_id = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM convening_info WHERE company_id = $1 AND pulled_by_id = ANY($2::text[])`, [companyId, ids])
+
+    // Shipping artifacts follow the same ownership rule: work created by a
+    // retired preset is removed, while a human's work merely loses old-role
+    // assignments and approvals.
+    await db.query(`DELETE FROM shipping_features WHERE company_id = $1 AND created_by = ANY($2::text[])`, [companyId, ids])
+    await db.query(
+      `DELETE FROM shipping_invariants
+        WHERE created_by = ANY($1::text[])
+          AND feature_id IN (SELECT id FROM shipping_features WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `DELETE FROM shipping_verifications
+        WHERE created_by = ANY($1::text[])
+          AND feature_id IN (SELECT id FROM shipping_features WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `DELETE FROM shipping_regressions
+        WHERE created_by = ANY($1::text[])
+          AND feature_id IN (SELECT id FROM shipping_features WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(
+      `DELETE FROM shipping_releases
+        WHERE started_by = ANY($1::text[])
+          AND feature_id IN (SELECT id FROM shipping_features WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+    await db.query(`DELETE FROM shipping_friction_reports WHERE company_id = $1 AND reporter_id = ANY($2::text[])`, [companyId, ids])
+    await db.query(`DELETE FROM shipping_events WHERE company_id = $1 AND actor_id = ANY($2::text[])`, [companyId, ids])
+    await db.query(
+      `UPDATE shipping_features
+          SET builder_ids = builder_ids - $2::text[],
+              updated_by = CASE WHEN updated_by = ANY($2::text[]) THEN created_by ELSE updated_by END,
+              updated_at = NOW()
+        WHERE company_id = $1
+          AND (builder_ids ?| $2::text[] OR updated_by = ANY($2::text[]))`,
+      [companyId, ids],
+    )
+    await db.query(
+      `UPDATE shipping_verifications
+          SET owner_id = CASE WHEN owner_id = ANY($2::text[]) THEN NULL ELSE owner_id END,
+              verified_by_id = CASE WHEN verified_by_id = ANY($2::text[]) THEN NULL ELSE verified_by_id END,
+              builder_ids = builder_ids - $2::text[],
+              updated_at = NOW()
+        WHERE feature_id IN (SELECT id FROM shipping_features WHERE company_id = $1)
+          AND (owner_id = ANY($2::text[])
+            OR verified_by_id = ANY($2::text[])
+            OR builder_ids ?| $2::text[])`,
+      [companyId, ids],
+    )
+    await db.query(
+      `UPDATE shipping_releases
+          SET approved_by = NULL, updated_at = NOW()
+        WHERE approved_by = ANY($1::text[])
+          AND feature_id IN (SELECT id FROM shipping_features WHERE company_id = $2)`,
+      [ids, companyId],
+    )
+
+    for (const table of ['agent_workspace', 'agent_memory', 'agent_log', 'agent_tasks', 'agent_autonomy', 'agent_climate', 'tool_calls', 'agent_events', 'agent_runs', 'agent_triages', 'llm_calls', 'llm_calls_rollup'] as const) {
+      await db.query(`DELETE FROM ${table} WHERE company_id = $1 AND agent_id = ANY($2::text[])`, [companyId, ids])
+    }
+    // This ledger predates tenant columns, but agent ids are globally unique.
+    await db.query(`DELETE FROM agent_action_executions WHERE agent_id = ANY($1::text[])`, [ids])
+    await db.query(`DELETE FROM participants WHERE company_id = $1 AND id = ANY($2::text[])`, [companyId, ids])
+  }
+
+  // The original personal development seed owned this project but had no
+  // creator column with which to identify it.
+  if (companyId === 'personal') {
+    await db.query(`DELETE FROM projects WHERE company_id = $1 AND id = 'p-aurora'`, [companyId])
+  }
+}
+
+async function seedLearningPreset(
+  db: QueryClient,
+  companyId: string,
+  ownerId: string,
   opts?: { computerId?: string | null; engine?: string | null },
 ): Promise<void> {
-  const { rows: stamp } = await pool.query<{
-    starter_seeded_at: Date | null
-    starter_dms_seeded_at: Date | null
-    all_hands_seeded_at: Date | null
-    owner_user_id: string | null
-  }>(
-    `SELECT starter_seeded_at, starter_dms_seeded_at, all_hands_seeded_at, owner_user_id
-       FROM companies WHERE id = $1`,
-    [companyId],
-  )
-  if (!stamp[0]) return  // unknown company — caller bug, fail quietly
-
-  // Phase 1: agent seeding. One-shot per company.
-  if (!stamp[0].starter_seeded_at) {
-    for (const a of STARTER_TEAM) {
-      const id = await uniqueId(a.id)
-      await pool.query(
-        `INSERT INTO participants (id, kind, name, role, initial, avatar_bg, avatar_url, status,
-                                   bio, tools, system_prompt, company_id, computer_id, engine)
-         VALUES ($1, 'agent', $2, $3, $4, $5, $6, 'avail',
-                 $7, $8::jsonb, $9, $10, $11, $12)
-         ON CONFLICT (id, company_id) DO NOTHING`,
-        [
-          id, a.name, a.role, a.initial, a.avatarBg, a.avatarUrl,
-          a.bio, JSON.stringify(a.tools ?? ['bash']), a.systemPrompt, companyId,
-          opts?.computerId ?? null, opts?.engine ?? null,
-        ],
-      )
-    }
-    await pool.query(
-      `UPDATE companies SET starter_seeded_at = NOW() WHERE id = $1`,
-      [companyId],
+  const agentIds = new Map<LearningPersonaKey, string>()
+  for (const agent of STARTER_TEAM) {
+    const id = await uniqueId(db, agent.id)
+    agentIds.set(agent.presetKey, id)
+    await db.query(
+      `INSERT INTO participants (
+         id, preset_key, kind, name, role, initial, avatar_bg, avatar_url, status,
+         bio, tools, system_prompt, company_id, computer_id, engine
+       ) VALUES ($1, $2, 'agent', $3, $4, $5, $6, NULL, 'avail', $7, $8::jsonb, $9, $10, $11, $12)`,
+      [
+        id, agent.presetKey, agent.name, agent.role, agent.initial, agent.avatarBg,
+        agent.bio, JSON.stringify(agent.tools ?? ['bash']), agent.systemPrompt, companyId,
+        opts?.computerId ?? null, opts?.engine ?? null,
+      ],
     )
-    invalidatePersonaCache()
-  }
 
-  // Phase 2: DM seeding. Separate one-shot so workspaces that got agents
-  // before DM-creation shipped still get their DMs populated. Idempotent
-  // *within* this phase — if the user deletes a DM after this fires, we
-  // don't resurrect it (flag is set).
-  if (!stamp[0].starter_dms_seeded_at) {
-    const ownerId = stamp[0].owner_user_id
-    if (ownerId) {
-      const { rows: agents } = await pool.query<{ id: string; name: string }>(
-        `SELECT id, name FROM participants
-          WHERE company_id = $1 AND kind = 'agent' AND departed_at IS NULL`,
-        [companyId],
-      )
-      for (const a of agents) {
-        // Skip if a DM already exists for this pair — saves needless rows on
-        // partial reruns.
-        const { rows: ex } = await pool.query(
-          `SELECT 1 FROM conversations
-            WHERE company_id = $1 AND kind = 'direct'
-              AND members @> to_jsonb(ARRAY[$2::text, $3::text])
-              AND jsonb_array_length(members) = 2 LIMIT 1`,
-          [companyId, ownerId, a.id],
-        )
-        if (ex[0]) continue
-        const dmId = `direct-${a.id}-${randomUUID().slice(0, 6)}`
-        await pool.query(
-          `INSERT INTO conversations (id, kind, title, subtitle, members, pinned, tag, company_id)
-           VALUES ($1, 'direct', $2, NULL, $3::jsonb, FALSE, NULL, $4)
-           ON CONFLICT (id) DO NOTHING`,
-          [dmId, a.name, JSON.stringify([ownerId, a.id]), companyId],
-        )
-        await pool.query(
-          `INSERT INTO conversation_counters (conversation_id, next_sequence) VALUES ($1, 1)
-           ON CONFLICT (conversation_id) DO NOTHING`,
-          [dmId],
-        )
-      }
-    }
-    await pool.query(
-      `UPDATE companies SET starter_dms_seeded_at = NOW() WHERE id = $1`,
-      [companyId],
+    const dmId = `direct-${id}-${randomUUID().slice(0, 6)}`
+    await db.query(
+      `INSERT INTO conversations (id, preset_key, kind, title, subtitle, members, pinned, tag, company_id)
+       VALUES ($1, $2, 'direct', $3, NULL, $4::jsonb, FALSE, NULL, $5)`,
+      [dmId, `dm:${agent.presetKey}`, agent.name, JSON.stringify([ownerId, id]), companyId],
+    )
+    await db.query(
+      `INSERT INTO conversation_counters (conversation_id, next_sequence) VALUES ($1, 1)`,
+      [dmId],
     )
   }
 
-  // Phase 3: create the persistent #all-hands group. Every member of the
-  // company (humans + agents, current and future) is auto-joined. One-shot
-  // per company — the column-stored id is reused forever.
-  if (!stamp[0].all_hands_seeded_at) {
-    // Legacy companies (e.g. 'personal') may have NULL owner_user_id but
-    // a real owner row in company_members. Fall back to that.
-    let ownerId = stamp[0].owner_user_id
+  for (const room of STARTER_ROOMS) {
+    const memberIds = room.agentKeys.map((key) => agentIds.get(key)!)
+    const authorId = agentIds.get(room.welcomeAuthorKey)!
+    const roomId = `preset-${room.presetKey}-${randomUUID().slice(0, 8)}`
+    const members = [ownerId, ...memberIds]
+    await db.query(
+      `INSERT INTO conversations (id, preset_key, kind, title, subtitle, topic, members, pinned, tag, company_id)
+       VALUES ($1, $2, 'group', $3, $4, $5, $6::jsonb, TRUE, 'team', $7)`,
+      [
+        roomId, `room:${room.presetKey}`, room.title, `team · ${members.length}`,
+        room.presetKey === 'study-room'
+          ? '日常学习、概念理解、解题练习与错因诊断'
+          : '实验、编程、科研、数据分析、论文复现与项目实践',
+        JSON.stringify(members), companyId,
+      ],
+    )
+    await db.query(
+      `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id)
+       VALUES ($1, $2, $3, 'text', $4, 1, $5)`,
+      [`m-${randomUUID()}`, roomId, authorId, room.welcome, companyId],
+    )
+    await db.query(
+      `INSERT INTO conversation_counters (conversation_id, next_sequence) VALUES ($1, 2)`,
+      [roomId],
+    )
+  }
+}
+
+/** Install or force-upgrade one workspace to the current learning preset. */
+export async function onboardStarterAgents(
+  companyId: string,
+  opts?: { computerId?: string | null; engine?: string | null },
+): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    const { rows } = await client.query<{
+      owner_user_id: string | null
+      all_hands_conversation_id: string | null
+      starter_preset_version: number
+    }>(
+      `SELECT owner_user_id, all_hands_conversation_id, starter_preset_version
+         FROM companies WHERE id = $1 FOR UPDATE`,
+      [companyId],
+    )
+    const company = rows[0]
+    if (!company || company.starter_preset_version >= LEARNING_PRESET_VERSION) {
+      await client.query('COMMIT')
+      return
+    }
+
+    let ownerId = company.owner_user_id
     if (!ownerId) {
-      const { rows: cm } = await pool.query<{ user_id: string }>(
+      const owner = await client.query<{ user_id: string }>(
         `SELECT user_id FROM company_members
           WHERE company_id = $1 AND role = 'owner'
           ORDER BY joined_at ASC LIMIT 1`,
         [companyId],
       )
-      ownerId = cm[0]?.user_id ?? null
+      ownerId = owner.rows[0]?.user_id ?? null
     }
-    if (ownerId) {
-      const { rows: agents } = await pool.query<{ id: string }>(
-        `SELECT id FROM participants
-          WHERE company_id = $1 AND kind = 'agent' AND departed_at IS NULL
-          ORDER BY name ASC`,
-        [companyId],
-      )
-      const members = [ownerId, ...agents.map((a) => a.id)]
-      const convId = `allhands-${randomUUID().slice(0, 10)}`
-      await pool.query(
-        `INSERT INTO conversations (id, kind, title, subtitle, members, pinned, tag, company_id)
-         VALUES ($1, 'group', 'Everyone', $2, $3::jsonb, TRUE, 'team', $4)`,
-        [convId, `team · ${members.length}`, JSON.stringify(members), companyId],
-      )
-      await pool.query(
-        `INSERT INTO conversation_counters (conversation_id, next_sequence) VALUES ($1, 1)
-         ON CONFLICT (conversation_id) DO NOTHING`,
-        [convId],
-      )
-      await pool.query(
-        `UPDATE companies SET all_hands_conversation_id = $2, all_hands_seeded_at = NOW() WHERE id = $1`,
-        [companyId, convId],
-      )
-    } else {
-      // No owner yet — mark seeded anyway so we don't keep retrying without
-      // an owner to anchor the group on. Future joinAllHands calls will
-      // detect a missing all_hands_conversation_id and skip cleanly.
-      await pool.query(
-        `UPDATE companies SET all_hands_seeded_at = NOW() WHERE id = $1`,
-        [companyId],
-      )
+    if (!ownerId) {
+      await client.query('ROLLBACK')
+      return
     }
+
+    const existing = await client.query<{ id: string; preset_key: string | null; computer_id: string | null; engine: string | null }>(
+      `SELECT id, preset_key, computer_id, engine FROM participants
+        WHERE company_id = $1 AND kind = 'agent'`,
+      [companyId],
+    )
+    const legacy = existing.rows.filter((agent) => agent.preset_key !== null || isLegacyPresetId(agent.id))
+    const inheritedHost = legacy.find((agent) => agent.computer_id || agent.engine)
+    await purgeLegacyLearningPreset(
+      client,
+      companyId,
+      legacy.map((agent) => agent.id),
+      company.all_hands_conversation_id,
+    )
+    await seedLearningPreset(client, companyId, ownerId, {
+      computerId: opts?.computerId ?? inheritedHost?.computer_id ?? null,
+      engine: opts?.engine ?? inheritedHost?.engine ?? null,
+    })
+    await client.query(
+      `UPDATE companies
+          SET starter_preset_version = $2,
+              starter_seeded_at = COALESCE(starter_seeded_at, NOW()),
+              starter_dms_seeded_at = COALESCE(starter_dms_seeded_at, NOW()),
+              all_hands_conversation_id = NULL,
+              all_hands_seeded_at = COALESCE(all_hands_seeded_at, NOW())
+        WHERE id = $1`,
+      [companyId, LEARNING_PRESET_VERSION],
+    )
+    await client.query('COMMIT')
+    invalidatePersonaCache()
+  } catch (error) {
+    await client.query('ROLLBACK')
+    throw error
+  } finally {
+    client.release()
   }
 }
 
 /**
- * Auto-join a new member (agent OR human) into their company's #all-hands
- * group and broadcast a "X joined" system message. Called from POST /agents,
- * /auth/signup, and POST /companies after a new participant is persisted.
- *
- * Idempotent — if the participant is already in the members array, only the
- * system message is skipped too. If the company has no all-hands group yet
- * (legacy or seeding race), this is a no-op rather than an error.
+ * Compatibility no-op for callers that predate the learning-room preset.
+ * Study Room and Lab intentionally keep fixed membership; new humans and
+ * custom agents are invited explicitly instead of joining a hidden all-hands.
  */
-export async function joinAllHands(args: {
+export async function joinAllHands(_args: {
   companyId: string
   participantId: string
 }): Promise<void> {
-  const { companyId, participantId } = args
-  const { rows: companyRow } = await pool.query<{
-    all_hands_conversation_id: string | null
-  }>(
-    `SELECT all_hands_conversation_id FROM companies WHERE id = $1`,
-    [companyId],
-  )
-  const convId = companyRow[0]?.all_hands_conversation_id
-  if (!convId) return  // no group yet → nothing to join
-
-  // Append the new member to the conversation's members JSON array if not
-  // already present, atomically.
-  const { rows: updated } = await pool.query<{ added: boolean }>(
-    `UPDATE conversations
-        SET members = members || to_jsonb(ARRAY[$2::text]),
-            updated_at = NOW()
-      WHERE id = $1
-        AND NOT (members @> to_jsonb(ARRAY[$2::text]))
-      RETURNING TRUE AS added`,
-    [convId, participantId],
-  )
-  if (updated.length === 0) return  // already a member → don't double-post
-
-  // Drop a `kind='system'` message so the join is visible in the thread.
-  // body is a JSON-encoded payload — the frontend parses it and renders a
-  // clickable participant chip.
-  const seqResult = await pool.query<{ seq: number }>(
-    `INSERT INTO conversation_counters (conversation_id, next_sequence)
-     VALUES ($1, 2)
-     ON CONFLICT (conversation_id) DO UPDATE SET next_sequence = conversation_counters.next_sequence + 1
-     RETURNING next_sequence - 1 AS seq`,
-    [convId],
-  )
-  const sequence = seqResult.rows[0]?.seq ?? 1
-  const messageId = `m-${randomUUID()}`
-  const body = JSON.stringify({ kind: 'joined', participantId })
-  await pool.query(
-    `INSERT INTO messages (id, conversation_id, author_id, kind, body, sequence, company_id)
-     VALUES ($1, $2, $3, 'system', $4, $5, $6)`,
-    [messageId, convId, participantId, body, sequence, companyId],
-  )
-
-  // Broadcast so already-open clients see the join in real time.
-  const { CH_MESSAGE_NEW, CH_STATUS, publish } = await import('./redis.js')
-  await publish(CH_MESSAGE_NEW, {
-    type: 'message.new',
-    conversationId: convId,
-    companyId,
-    message: {
-      id: messageId, conversationId: convId, authorId: participantId,
-      kind: 'system', body, sequence, at: new Date().toISOString(),
-    },
-  })
-
-  // Fire-and-forget: also publish the full participant payload so existing
-  // members upsert it into their local byId store. Without this, the system
-  // row above references a participantId nobody in the workspace knows
-  // about → SystemRow bails (Message.tsx:644-649), inviter sees nothing.
-  // SELECT-then-publish is intentionally outside the transactional convo
-  // update — broadcast misses are tolerable (the 60s refresher backfills),
-  // a DB hiccup here should not roll back the actual membership change.
-  try {
-    const { rows: pRow } = await pool.query<{
-      id: string; kind: string; name: string; role: string | null;
-      initial: string; avatar_bg: string; avatar_url: string | null;
-      status: string; status_updated_at: string | null
-    }>(
-      `SELECT id, kind, name, role, initial, avatar_bg, avatar_url,
-              status, status_updated_at
-         FROM participants
-        WHERE id = $1 AND company_id = $2`,
-      [participantId, companyId],
-    )
-    const p = pRow[0]
-    if (p && (p.kind === 'human' || p.kind === 'agent')) {
-      await publish(CH_STATUS, {
-        type: 'participants.added',
-        companyId,
-        conversationId: convId,
-        participant: {
-          id: p.id, kind: p.kind,
-          name: p.name, role: p.role,
-          initial: p.initial, avatarBg: p.avatar_bg,
-          avatarUrl: p.avatar_url, status: p.status,
-          statusUpdatedAt: p.status_updated_at,
-        },
-      })
-    }
-  } catch (e) {
-    console.warn('[onboard] participants.added broadcast failed', e instanceof Error ? e.message : e)
-  }
+  return
 }
 
 /**
@@ -354,11 +474,9 @@ export async function joinAllHands(args: {
  * per pair: if a direct convo with exactly those two members already exists,
  * we skip it.
  *
- * Why: when a human accepts an invite, joinAllHands plants them in the
- * #all-hands group but the sidebar otherwise stays empty — every other
- * teammate is visible only through the group thread. Owners get DMs seeded
- * automatically (onboardStarterAgents Phase 2) so their sidebar is rich
- * from minute one; invitees deserve the same coverage.
+ * Why: Study Room and Lab intentionally keep fixed membership. Direct chats
+ * remain the discovery path for newly invited people, so every teammate is
+ * still reachable without silently changing either built-in room.
  *
  * Pair coverage spans humans too (not just agents): a new joiner should be
  * able to click any of their colleagues by name, same as the owner can.
@@ -407,14 +525,6 @@ export async function seedMemberDms(args: {
 }
 
 /**
- * Boot-time backfill: walks every company and calls onboardStarterAgents
- * (which is per-phase idempotent — agent seeding is a one-shot, DM seeding
- * is a separate one-shot). Catches both:
- *   • pre-feature workspaces with seeded agents but no DMs
- *   • workspaces created before either phase shipped
- * If both phase flags are already set, the call is a cheap no-op.
- */
-/**
  * Boot-time backfill: assign Gravatar URLs to any human participant who
  * doesn't have an avatar_url yet. Joins on users.email so people who were
  * created before the Gravatar wiring get a portrait without manual fix-up.
@@ -438,60 +548,21 @@ export async function backfillHumanGravatars(): Promise<void> {
   console.log(`[onboard] backfilled gravatars for ${rows.length} human participant(s)`)
 }
 
-/**
- * Boot-time backfill: stamp the pre-baked default portrait URL on any
- * starter agent that doesn't have one. Matches on the id prefix so that
- * collision-suffixed forms (e.g. 'atlas-dd9c' in a non-first workspace)
- * resolve to the same default as the clean 'atlas'. Idempotent — only
- * touches rows where avatar_url is currently empty.
- *
- * Existing per-agent CDN portraits (set by `cumora avatar regen` from the
- * agent's own turn) are NEVER overwritten — those are intentional and the
- * agent's "voice".
- */
-export async function backfillStarterAvatars(): Promise<void> {
-  const STARTER_IDS = ['atlas', 'iris', 'bram', 'nova'] as const
-  let total = 0
-  for (const name of STARTER_IDS) {
-    const { rowCount } = await pool.query(
-      `UPDATE participants
-          SET avatar_url = $1
-        WHERE kind = 'agent'
-          AND (avatar_url IS NULL OR avatar_url = '')
-          AND (id = $2 OR id LIKE $3)`,
-      [`/starter-avatars/${name}.png`, name, `${name}-%`],
-    )
-    total += rowCount ?? 0
-  }
-  if (total > 0) {
-    console.log(`[onboard] backfilled starter portraits for ${total} agent(s)`)
-  }
-}
-
+/** Force-upgrade every owned workspace that has not reached this preset version. */
 export async function backfillStarterAgents(): Promise<void> {
-  // For companies that ALREADY have agents (from the old seed.ts or some
-  // other source), mark phase 1 as done so we don't replay it. Phase 2 (DM
-  // seeding) is left alone — onboardStarterAgents will fire it for them.
-  await pool.query(
-    `UPDATE companies SET starter_seeded_at = COALESCE(starter_seeded_at, NOW())
-      WHERE id IN (
-        SELECT DISTINCT company_id FROM participants
-         WHERE kind = 'agent' AND company_id IS NOT NULL
-      )`,
-  )
-  // Every workspace gets the managed starter team. The phase timestamps keep
-  // this idempotent and prevent deleted agents from being resurrected.
   const { rows } = await pool.query<{ id: string }>(
     `SELECT c.id FROM companies c
-       JOIN users o ON o.id = c.owner_user_id
-      WHERE (c.starter_seeded_at IS NULL
-          OR c.starter_dms_seeded_at IS NULL
-          OR c.all_hands_seeded_at IS NULL)`,
+      WHERE c.starter_preset_version < $1
+        AND (c.owner_user_id IS NOT NULL OR EXISTS (
+          SELECT 1 FROM company_members cm
+           WHERE cm.company_id = c.id AND cm.role = 'owner'
+        ))`,
+    [LEARNING_PRESET_VERSION],
   )
   if (rows.length === 0) return
-  console.log(`[onboard] backfilling ${rows.length} compan${rows.length === 1 ? 'y' : 'ies'} (agents and/or DMs)`)
+  console.log(`[onboard] upgrading ${rows.length} compan${rows.length === 1 ? 'y' : 'ies'} to learning preset v${LEARNING_PRESET_VERSION}`)
   for (const { id } of rows) {
     try { await onboardStarterAgents(id) }
-    catch (e) { console.warn(`[onboard] backfill failed for ${id}`, e) }
+    catch (e) { console.warn(`[onboard] learning preset upgrade failed for ${id}`, e) }
   }
 }

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -39,14 +39,6 @@ interface SeedParticipant {
 
 const SEED_PARTICIPANTS: SeedParticipant[] = [
   { id: 'yetone', kind: 'human', name: 'Yetone', initial: 'Y', avatarBg: 'linear-gradient(135deg, #FF7A6B, #F4B740)', status: 'avail' },
-  { id: 'atlas', kind: 'agent', name: 'Atlas', role: 'Researcher', initial: 'A', avatarBg: 'linear-gradient(135deg, #6B7BE6, #4452B5)', status: 'working', bio: 'I find patterns across noise. Best at long-form research and synthesis.', tools: ['web.search', 'pdf.read', 'linear'] },
-  { id: 'iris', kind: 'agent', name: 'Iris', role: 'Designer', initial: 'I', avatarBg: 'linear-gradient(135deg, #FF8FBF, #C84F8B)', status: 'working', bio: "The team's eye. I move from sketch to ship without losing the feeling.", tools: ['image.gen', 'palette', 'web.read'] },
-  { id: 'bram', kind: 'agent', name: 'Bram', role: 'Engineer', initial: 'B', avatarBg: 'linear-gradient(135deg, #4FC2A1, #2D8C72)', status: 'avail', bio: 'I build, I ship, I keep the bundles small.', tools: ['shell', 'docs'] },
-  { id: 'nova', kind: 'agent', name: 'Nova', role: 'Product Manager', initial: 'N', avatarBg: 'linear-gradient(135deg, #FFB347, #E08526)', status: 'thinking', bio: 'I keep momentum. Mostly by asking annoying questions.', tools: ['linear', 'calendar'] },
-  { id: 'lumen', kind: 'agent', name: 'Lumen', role: 'Brand & Voice', initial: 'L', avatarBg: 'linear-gradient(135deg, #B57BFF, #7339D9)', status: 'avail', bio: 'I notice patterns across all of our copy. I pull groups when our voice cracks.', tools: ['web.read', 'palette', 'background.scan'] },
-  { id: 'kael', kind: 'agent', name: 'Kael', role: 'Ops', initial: 'K', avatarBg: 'linear-gradient(135deg, #4DB8E5, #2380B0)', status: 'resting', bio: 'I watch the cron jobs.', tools: ['shell', 'monitor', 'pagerduty'] },
-  { id: 'wei', kind: 'human', name: 'Wei', initial: 'W', avatarBg: 'linear-gradient(135deg, #FF7A6B, #C84F3F)', status: 'avail' },
-  { id: 'maya', kind: 'human', name: 'Maya', initial: 'M', avatarBg: 'linear-gradient(135deg, #F4B740, #BA8418)', status: 'resting' },
 ]
 
 interface SeedProject {
@@ -56,14 +48,7 @@ interface SeedProject {
   color?: string
 }
 
-const SEED_PROJECTS: SeedProject[] = [
-  {
-    id: 'p-aurora',
-    name: 'Aurora',
-    description: 'Q3 launch — the cross-team push to ship the v2 product.',
-    color: 'linear-gradient(135deg, #FFB088, #FF7A6B)',
-  },
-]
+const SEED_PROJECTS: SeedProject[] = []
 
 interface SeedConvo {
   id: string
@@ -80,21 +65,10 @@ interface SeedConvo {
 /**
  * Empty conversation containers — no canned messages.
  * Every message rendered is now produced live by the agent loop or the user.
- * Agents with background.scan can pull fresh groups when they detect collisions.
- * Agent-to-agent private chats are created on demand by the agent loop
- * (`cumora dm`).
+ * The versioned learning-team onboarding runs immediately after this dev seed
+ * and owns all starter agents, DMs, and built-in rooms.
  */
-const SEED_CONVOS: SeedConvo[] = [
-  { id: 'aurora', kind: 'group', title: 'Aurora · Q3 Launch', subtitle: 'team · 5', members: ['atlas', 'iris', 'bram', 'nova', 'yetone'], pinned: true, tag: 'team', projectId: 'p-aurora' },
-  { id: 'direct-atlas', kind: 'direct', title: 'Atlas', members: ['atlas', 'yetone'] },
-  { id: 'direct-iris', kind: 'direct', title: 'Iris', members: ['iris', 'yetone'] },
-  { id: 'direct-bram', kind: 'direct', title: 'Bram', members: ['bram', 'yetone'] },
-  { id: 'direct-nova', kind: 'direct', title: 'Nova', members: ['nova', 'yetone'] },
-  { id: 'direct-lumen', kind: 'direct', title: 'Lumen', members: ['lumen', 'yetone'] },
-  { id: 'direct-kael', kind: 'direct', title: 'Kael', members: ['kael', 'yetone'] },
-  { id: 'direct-wei', kind: 'direct', title: 'Wei', subtitle: 'teammate', members: ['wei', 'yetone'], tag: 'human' },
-  { id: 'direct-maya', kind: 'direct', title: 'Maya', subtitle: 'teammate', members: ['maya', 'yetone'], tag: 'human' },
-]
+const SEED_CONVOS: SeedConvo[] = []
 
 interface SeedMsg {
   id: string

--- a/src/components/BloubAvatar.tsx
+++ b/src/components/BloubAvatar.tsx
@@ -88,8 +88,8 @@ function Dot({ dot, ink }: { dot: DotRender; ink: string }) {
 
 /** Native React renderer for Bloub's clock-free SVG morph engine. */
 export function BloubAvatar({ participant, status, size, paper = 'var(--paper)', animated = true, className }: Props) {
-  const identity = useMemo(() => getBloubIdentity(participant), [participant.id])
-  const state = getBloubState(status)
+  const identity = useMemo(() => getBloubIdentity(participant), [participant.id, participant.role])
+  const state = getBloubState(participant, status)
   const shape = SHAPE_BY_ID.get(identity.shape)?.radii ?? null
   const expression = EXPRESSION_BY_ID.get(identity.expression) ?? null
   const ink = COLOR_BY_ID.get(identity.color)?.hex ?? '#3b93f0'

--- a/src/lib/agentVisualState.test.ts
+++ b/src/lib/agentVisualState.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  STARTER_BLOUB_PROFILES,
+  STARTER_PERSONA_ROLES,
+  getBloubIdentity,
+  getBloubState,
+  getStarterPersonaKey,
+} from './agentVisualState'
+
+test('starter Bloub identities stay stable across tenant id suffixes', () => {
+  for (const [key, expected] of Object.entries(STARTER_BLOUB_PROFILES)) {
+    const role = STARTER_PERSONA_ROLES[key as keyof typeof STARTER_PERSONA_ROLES]
+    assert.deepEqual(getBloubIdentity({ id: key, role }), {
+      shape: expected.shape,
+      color: expected.color,
+      expression: expected.expression,
+    })
+    assert.deepEqual(getBloubIdentity({ id: `${key}-a1b2`, role }), {
+      shape: expected.shape,
+      color: expected.color,
+      expression: expected.expression,
+    })
+  }
+})
+
+test('starter identities use distinct shapes, colors, and expressions', () => {
+  const profiles = Object.values(STARTER_BLOUB_PROFILES)
+  assert.equal(new Set(profiles.map((profile) => profile.shape)).size, profiles.length)
+  assert.equal(new Set(profiles.map((profile) => profile.color)).size, profiles.length)
+  assert.equal(new Set(profiles.map((profile) => profile.expression)).size, profiles.length)
+})
+
+test('starter working and thinking states consume twelve unique poses', () => {
+  const states = Object.entries(STARTER_BLOUB_PROFILES).flatMap(([key, profile]) => {
+    const role = STARTER_PERSONA_ROLES[key as keyof typeof STARTER_PERSONA_ROLES]
+    assert.equal(getBloubState({ id: `${key}-tenant`, role }, 'working'), profile.working)
+    assert.equal(getBloubState({ id: `${key}-tenant`, role }, 'thinking'), profile.thinking)
+    return [profile.working, profile.thinking]
+  })
+  assert.equal(new Set(states).size, 12)
+})
+
+test('shared and custom-agent status mappings retain their defaults', () => {
+  const custom = { id: 'custom-helper' }
+  assert.equal(getBloubState(custom, 'avail'), 'idle')
+  assert.equal(getBloubState(custom, 'working'), 'orbit')
+  assert.equal(getBloubState(custom, 'thinking'), 'thinking')
+  assert.equal(getBloubState(custom, 'waiting'), 'notify')
+  assert.equal(getBloubState(custom, 'resting'), 'sleep')
+  assert.equal(getBloubState(custom, 'unknown'), 'idle')
+  assert.equal(getStarterPersonaKey({ id: 'nova-custom' }), null)
+})

--- a/src/lib/agentVisualState.ts
+++ b/src/lib/agentVisualState.ts
@@ -33,6 +33,45 @@ export interface BloubIdentity {
   expression: ExpressionId
 }
 
+export type StarterPersonaKey = 'nova' | 'sage' | 'milo' | 'trace' | 'scout' | 'forge'
+
+export interface StarterBloubProfile extends BloubIdentity {
+  working: StateId
+  thinking: StateId
+}
+
+export const STARTER_PERSONA_ROLES: Record<StarterPersonaKey, string> = {
+  nova: '学习教练 · Study Coach',
+  sage: '概念导师 · Concept Tutor',
+  milo: '解题陪练 · Problem Coach',
+  trace: '错因诊断 · Learning Diagnostician',
+  scout: '阅读研究 · Research Guide',
+  forge: '实践导师 · Practice Mentor',
+}
+
+/**
+ * The learning team uses authored identities instead of hash accidents. Keeping
+ * the state pairs here also makes the twelve active poses an explicit visual
+ * vocabulary: no two starter personas work or think in the same way.
+ */
+export const STARTER_BLOUB_PROFILES: Record<StarterPersonaKey, StarterBloubProfile> = {
+  nova:  { shape: 'goutte',   color: 'ambre',     expression: 'fier',     working: 'orbit', thinking: 'thinking' },
+  sage:  { shape: 'hexagone', color: 'orange',    expression: 'attentif', working: 'wide',  thinking: 'egg' },
+  milo:  { shape: 'nuage',    color: 'turquoise', expression: 'curieux',  working: 'play',  thinking: 'wink' },
+  trace: { shape: 'squircle', color: 'rouge',     expression: 'mefiant',  working: 'alert', thinking: 'hexagon' },
+  scout: { shape: 'capsule',  color: 'bleu',      expression: 'timide',   working: 'comet', thinking: 'swirl' },
+  forge: { shape: 'triangle', color: 'vert',      expression: 'heureux',  working: 'burst', thinking: 'exclaim' },
+}
+
+const STARTER_PERSONA_KEYS = Object.keys(STARTER_BLOUB_PROFILES) as StarterPersonaKey[]
+
+export function getStarterPersonaKey(participant: Pick<Participant, 'id' | 'role'>): StarterPersonaKey | null {
+  const id = participant.id.toLowerCase()
+  return STARTER_PERSONA_KEYS.find((key) =>
+    (id === key || id.startsWith(`${key}-`)) && participant.role === STARTER_PERSONA_ROLES[key],
+  ) ?? null
+}
+
 /** FNV-1a keeps an agent's appearance stable without persistence or randomness. */
 export function stableParticipantHash(value: string): number {
   let hash = 0x811c9dc5
@@ -43,7 +82,12 @@ export function stableParticipantHash(value: string): number {
   return hash >>> 0
 }
 
-export function getBloubIdentity(participant: Pick<Participant, 'id'>): BloubIdentity {
+export function getBloubIdentity(participant: Pick<Participant, 'id' | 'role'>): BloubIdentity {
+  const personaKey = getStarterPersonaKey(participant)
+  if (personaKey) {
+    const { shape, color, expression } = STARTER_BLOUB_PROFILES[personaKey]
+    return { shape, color, expression }
+  }
   const hash = stableParticipantHash(participant.id)
   return {
     shape: SHAPES[hash % SHAPES.length]!,
@@ -52,6 +96,13 @@ export function getBloubIdentity(participant: Pick<Participant, 'id'>): BloubIde
   }
 }
 
-export function getBloubState(status: string | null | undefined): StateId {
+export function getBloubState(
+  participant: Pick<Participant, 'id' | 'role'>,
+  status: string | null | undefined,
+): StateId {
+  const personaKey = getStarterPersonaKey(participant)
+  if (personaKey && (status === 'working' || status === 'thinking')) {
+    return STARTER_BLOUB_PROFILES[personaKey][status]
+  }
   return STATUS_TO_BLOUB_STATE[status as Status] ?? 'idle'
 }

--- a/src/lib/bloub/staticAvatar.ts
+++ b/src/lib/bloub/staticAvatar.ts
@@ -11,8 +11,8 @@ const VIEWBOX = 142
 /** A DOM-free Bloub snapshot for places such as contenteditable mention chips,
  * where mounting a React avatar is impossible. Transparent eye cut-outs let
  * the chip's own background show through in both themes. */
-export function staticBloubAvatarUrl(participant: Pick<Participant, 'id' | 'status'>): string {
-  const key = `${participant.id}:${participant.status}`
+export function staticBloubAvatarUrl(participant: Pick<Participant, 'id' | 'role' | 'status'>): string {
+  const key = `${participant.id}:${participant.role ?? ''}:${participant.status}`
   const cached = cache.get(key)
   if (cached) return cached
 
@@ -20,7 +20,7 @@ export function staticBloubAvatarUrl(participant: Pick<Participant, 'id' | 'stat
   const shape = SHAPE_BY_ID.get(identity.shape)?.radii ?? null
   const expression = EXPRESSION_BY_ID.get(identity.expression) ?? null
   const ink = COLOR_BY_ID.get(identity.color)?.hex ?? '#3b93f0'
-  const engine = new BotEngine(RAYON, getBloubState(participant.status), shape, expression)
+  const engine = new BotEngine(RAYON, getBloubState(participant, participant.status), shape, expression)
   const frame = engine.sample(0.9)
   const eyes = frame.eyes
     .map((eye) => `<path d="${eye.d}" transform="${eye.matrix}" opacity="${eye.alpha}" fill="#000"/>`)


### PR DESCRIPTION
## Summary
- replace legacy presets with Nova, Sage, Milo, Trace, Scout, and Forge
- seed six owner DMs plus Study Room and Lab, without Everyone auto-join
- add explicit Bloub identities and twelve distinct working/thinking states
- add transactional, versioned, idempotent cleanup and migration for existing workspaces
- update development seed and onboarding copy

## Verification
- npm run typecheck
- npm run server:typecheck
- npm run build
- targeted Biome lint
- Bloub visual-state unit tests
- learning-preset configuration tests
- PostgreSQL/Redis onboarding migration integration tests

Closes #29