### PR TITLE
refactor(runtime): use LingxiGraph durable steering

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ directly.
 
 ## Production architecture
 
+### Steering ownership
+
+For `LINGXILOOP_REASONING_RUNTIME=lingxigraph`, LingxiGraph is the canonical
+owner of runtime steering. LingxiLoop resolves a trusted active run and maps a
+new stored chat message to `POST /v1/runs/{run_id}/steer`, using the stable
+message ID as the idempotency key. Accepted and duplicate events remain in the
+current run; terminal/finalizing runs and permanent adapter rejections fall
+back to the normal wake/new-turn path. Ambiguous transient failures do not
+immediately create a second turn (the original message remains durable in
+Loop), so a message is never both steered and immediately started as a second
+turn. LingxiGraph owns ordering, durable inbox storage,
+safe-point consumption, recovery, and steering lifecycle events.
+
+The local `server/src/agents/steer.ts` queue is legacy-runtime compatibility
+only and is not a steering source of truth for the LingxiGraph server path.
+
 ```text
 Web browser ─────────────┐
                         ├─ HTTPS / WebSocket ─ Reverse proxy ─ 127.0.0.1:5181

--- a/server/src/__tests__/agents-lingxigraph-adapter.test.ts
+++ b/server/src/__tests__/agents-lingxigraph-adapter.test.ts
@@ -9,6 +9,8 @@ import {
   executeCommunicationActions,
   parseLingxiGraphRunResult,
   runLingxiGraph,
+  steerLingxiGraphRun,
+  LingxiGraphSteerError,
 } from '../agents/lingxigraph-adapter.js'
 
 const result = (actions: unknown[]) => ({
@@ -17,6 +19,40 @@ const result = (actions: unknown[]) => ({
   reason: 'handled',
   actions,
   modelCalls: [{ model: 'test-model', usage: null }],
+})
+
+test('steering adapter posts a stable idempotency key and recognizes duplicates', async () => {
+  let seenUrl = ''
+  let seenInit: RequestInit = {}
+  const output = await steerLingxiGraphRun({
+    runId: 'run/one', kind: 'message.new', payload: { messageId: 'm1' }, idempotencyKey: 'm1',
+  }, {
+    url: 'http://runtime.local:8124', token: 'secret',
+    fetchImpl: fakeFetch((url, init) => {
+      seenUrl = url; seenInit = init
+      return new Response(JSON.stringify({ status: 'duplicate', eventId: 'evt-1' }), { status: 200 })
+    }),
+  })
+  assert.equal(seenUrl, 'http://runtime.local:8124/v1/runs/run%2Fone/steer')
+  assert.equal((seenInit.headers as Record<string, string>)['idempotency-key'], 'm1')
+  assert.deepEqual(output, { outcome: 'duplicate', eventId: 'evt-1' })
+})
+
+test('steering adapter classifies terminal rejection and transient failures', async () => {
+  const terminal = await steerLingxiGraphRun({ runId: 'r1', kind: 'message.new', payload: {}, idempotencyKey: 'm1' }, {
+    url: 'http://runtime.local', fetchImpl: fakeFetch(() => new Response(JSON.stringify({ code: 'run_finalizing' }), { status: 409 })),
+  })
+  assert.equal(terminal.outcome, 'terminal')
+  await assert.rejects(steerLingxiGraphRun({ runId: 'r1', kind: 'message.new', payload: {}, idempotencyKey: 'm1' }, {
+    url: 'http://runtime.local', fetchImpl: fakeFetch(() => new Response('unavailable', { status: 503 })),
+  }), (error: unknown) => error instanceof LingxiGraphSteerError && error.transient)
+})
+
+test('steering adapter recognizes a 409 duplicate as already handled', async () => {
+  const duplicate = await steerLingxiGraphRun({ runId: 'r1', kind: 'message.new', payload: {}, idempotencyKey: 'm1' }, {
+    url: 'http://runtime.local', fetchImpl: fakeFetch(() => new Response(JSON.stringify({ status: 'duplicate', event_id: 'e1' }), { status: 409 })),
+  })
+  assert.deepEqual(duplicate, { outcome: 'duplicate', eventId: 'e1' })
 })
 
 test('strictly validates actions before execution', () => {

--- a/server/src/__tests__/agents-lingxigraph-steering-router.test.ts
+++ b/server/src/__tests__/agents-lingxigraph-steering-router.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { beforeEach, test } from 'node:test'
+import { _resetActiveLingxiGraphRunsForTests, registerActiveLingxiGraphRun } from '../agents/lingxigraph-active-runs.js'
+import { routeLingxiGraphSteering } from '../agents/lingxigraph-steering-router.js'
+import { LingxiGraphSteerError } from '../agents/lingxigraph-adapter.js'
+
+beforeEach(_resetActiveLingxiGraphRunsForTests)
+const message = { messageId: 'm1', conversationId: 'c1', authorId: 'u1', authorName: 'User', body: 'follow up', companyId: 'tenant-1' }
+
+test('accepted and duplicate steering do not start a new turn', async () => {
+  registerActiveLingxiGraphRun({ agentId: 'a1', runId: 'r1', companyId: 'tenant-1' })
+  for (const outcome of ['accepted', 'duplicate'] as const) {
+    const calls: unknown[] = []
+    const routed = await routeLingxiGraphSteering('a1', message, async (request) => {
+      calls.push(request)
+      return { outcome, eventId: 'e1' }
+    })
+    assert.equal(routed.handled, true)
+    assert.equal((calls[0] as { idempotencyKey: string }).idempotencyKey, 'm1')
+  }
+})
+
+test('terminal/permanent failures fall back, transient ambiguity does not double-process, and tenant mismatch never submits', async () => {
+  registerActiveLingxiGraphRun({ agentId: 'a1', runId: 'r1', companyId: 'tenant-1' })
+  assert.equal((await routeLingxiGraphSteering('a1', message, async () => ({ outcome: 'terminal', eventId: null, reason: 'finalizing' }))).handled, false)
+  assert.equal((await routeLingxiGraphSteering('a1', message, async () => { throw new Error('invalid') })).handled, false)
+  assert.equal((await routeLingxiGraphSteering('a1', message, async () => { throw new LingxiGraphSteerError('timeout', true) })).handled, true)
+  let called = false
+  assert.equal((await routeLingxiGraphSteering('a1', { ...message, companyId: 'tenant-2' }, async () => { called = true; return { outcome: 'accepted', eventId: null } })).handled, false)
+  assert.equal(called, false)
+})

--- a/server/src/agents/lingxigraph-active-runs.ts
+++ b/server/src/agents/lingxigraph-active-runs.ts
@@ -1,0 +1,26 @@
+/** Trusted, process-local index of LingxiGraph calls currently in flight.
+ * The run id is registered by the turn runner, never supplied by a message.
+ * LingxiGraph remains the durable owner after a steer has been accepted. */
+export interface ActiveLingxiGraphRun {
+  runId: string
+  agentId: string
+  companyId: string | null
+}
+
+const activeRuns = new Map<string, ActiveLingxiGraphRun>()
+
+export function registerActiveLingxiGraphRun(run: ActiveLingxiGraphRun): void {
+  activeRuns.set(run.agentId, run)
+}
+
+export function clearActiveLingxiGraphRun(agentId: string, runId: string): void {
+  if (activeRuns.get(agentId)?.runId === runId) activeRuns.delete(agentId)
+}
+
+export function getActiveLingxiGraphRun(agentId: string): ActiveLingxiGraphRun | null {
+  return activeRuns.get(agentId) ?? null
+}
+
+export function _resetActiveLingxiGraphRunsForTests(): void {
+  activeRuns.clear()
+}

--- a/server/src/agents/lingxigraph-adapter.ts
+++ b/server/src/agents/lingxigraph-adapter.ts
@@ -50,6 +50,25 @@ export interface LingxiGraphAdapterOptions {
   fetchImpl?: typeof fetch
 }
 
+export interface LingxiGraphSteerRequest {
+  runId: string
+  kind: string
+  payload: Record<string, unknown>
+  metadata?: Record<string, unknown>
+  idempotencyKey: string
+}
+
+export type LingxiGraphSteerResult =
+  | { outcome: 'accepted' | 'duplicate'; eventId: string | null }
+  | { outcome: 'terminal'; eventId: null; reason: string }
+
+export class LingxiGraphSteerError extends Error {
+  constructor(message: string, readonly transient: boolean, readonly status?: number) {
+    super(message)
+    this.name = 'LingxiGraphSteerError'
+  }
+}
+
 export interface CommunicationExecutionResult {
   completed: boolean
   results: CliResult[]
@@ -380,6 +399,61 @@ export async function runLingxiGraph(
     } catch (error) {
       throw new Error(`invalid LingxiGraph runtime response: ${error instanceof Error ? error.message : String(error)}`)
     }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Submit communication input to LingxiGraph's durable steering inbox. */
+export async function steerLingxiGraphRun(
+  request: LingxiGraphSteerRequest,
+  options: LingxiGraphAdapterOptions = {},
+): Promise<LingxiGraphSteerResult> {
+  const baseUrl = options.url ?? process.env.LINGXIGRAPH_URL
+  if (!baseUrl) throw new LingxiGraphSteerError('LINGXIGRAPH_URL is required to reach the LingxiGraph runtime', false)
+  if (!request.runId.trim() || !request.idempotencyKey.trim()) throw new LingxiGraphSteerError('runId and idempotencyKey are required', false)
+  const token = options.token ?? process.env.LINGXIGRAPH_TOKEN
+  const timeoutMs = options.timeoutMs ?? Number(process.env.LINGXIGRAPH_STEER_TIMEOUT_MS ?? 10_000)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    let response: Response
+    try {
+      response = await (options.fetchImpl ?? fetch)(new URL(`/v1/runs/${encodeURIComponent(request.runId)}/steer`, baseUrl), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'idempotency-key': request.idempotencyKey,
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          kind: request.kind,
+          payload: request.payload,
+          ...(request.metadata ? { metadata: request.metadata } : {}),
+          idempotencyKey: request.idempotencyKey,
+        }),
+        signal: controller.signal,
+      })
+    } catch (error) {
+      const timedOut = error instanceof Error && error.name === 'AbortError'
+      throw new LingxiGraphSteerError(timedOut ? `LingxiGraph steering timed out after ${timeoutMs}ms` : `LingxiGraph steering request failed: ${error instanceof Error ? error.message : String(error)}`, true)
+    }
+    const text = await response.text().catch((error) => { throw new LingxiGraphSteerError(`LingxiGraph steering response failed: ${String(error)}`, true, response.status) })
+    let body: Record<string, unknown> = {}
+    if (text) {
+      try { const parsed = JSON.parse(text); if (isRecord(parsed)) body = parsed } catch { /* status remains authoritative */ }
+    }
+    const state = String(body.status ?? body.outcome ?? body.code ?? '').toLowerCase()
+    const eventId = typeof body.eventId === 'string' ? body.eventId : typeof body.event_id === 'string' ? body.event_id : null
+    // Some runtimes report an idempotent replay as 409 while others use
+    // 200/202. In either form it was already durably accepted and must not
+    // fall through into a second turn.
+    if (state.includes('duplicate')) return { outcome: 'duplicate', eventId }
+    if (response.ok) return { outcome: 'accepted', eventId }
+    if ([409, 410, 422].includes(response.status) && /(terminal|finaliz|completed|not.?running|closed)/.test(`${state} ${text}`.toLowerCase())) {
+      return { outcome: 'terminal', eventId: null, reason: text || `run rejected steering (${response.status})` }
+    }
+    throw new LingxiGraphSteerError(`LingxiGraph steering responded ${response.status}${text ? `: ${text}` : ''}`, response.status === 408 || response.status === 429 || response.status >= 500, response.status)
   } finally {
     clearTimeout(timer)
   }

--- a/server/src/agents/lingxigraph-steering-router.ts
+++ b/server/src/agents/lingxigraph-steering-router.ts
@@ -1,0 +1,43 @@
+import { getActiveLingxiGraphRun } from './lingxigraph-active-runs.js'
+import { LingxiGraphSteerError, steerLingxiGraphRun, type LingxiGraphSteerResult } from './lingxigraph-adapter.js'
+
+export interface LoopSteeringMessage {
+  messageId: string
+  conversationId: string
+  authorId?: string
+  authorName: string
+  body: string
+  companyId?: string
+}
+
+export async function routeLingxiGraphSteering(
+  agentId: string,
+  message: LoopSteeringMessage,
+  submit: typeof steerLingxiGraphRun = steerLingxiGraphRun,
+): Promise<{ handled: boolean; result?: LingxiGraphSteerResult; runId?: string }> {
+  const active = getActiveLingxiGraphRun(agentId)
+  if (!active || active.companyId !== (message.companyId || null)) return { handled: false }
+  try {
+    const result = await submit({
+      runId: active.runId,
+      kind: 'message.new',
+      idempotencyKey: message.messageId,
+      payload: {
+        messageId: message.messageId,
+        conversationId: message.conversationId,
+        authorId: message.authorId ?? '',
+        authorName: message.authorName,
+        body: message.body,
+      },
+      metadata: { agentId, companyId: active.companyId },
+    })
+    return { handled: result.outcome !== 'terminal', result, runId: active.runId }
+  } catch (error) {
+    // A timeout/5xx is ambiguous: Graph may have committed the durable event
+    // before the response was lost. Treat it as handled for this wake to avoid
+    // steer + new-turn double processing. The unread Loop message remains the
+    // communication-layer recovery record, and retries reuse messageId.
+    if (error instanceof LingxiGraphSteerError && error.transient) return { handled: true, runId: active.runId }
+    return { handled: false, runId: active.runId }
+  }
+}

--- a/server/src/agents/scheduler.ts
+++ b/server/src/agents/scheduler.ts
@@ -32,6 +32,7 @@ import { inprocClient, isAgentBusy } from './runtime/inproc-client.js'
 import { classifyInboxTriage, type InboxTriageVerdict } from './inbox-triage.js'
 import type { AgentTurnOptions } from './turn.js'
 import { scheduleManagedAgentTurn } from './managed-executor.js'
+import { routeLingxiGraphSteering } from './lingxigraph-steering-router.js'
 import { Semaphore } from '../concurrency.js'
 import { parseMentions } from '../mentions.js'
 import { resolveAgentRecipients } from './message-routing.js'
@@ -50,6 +51,7 @@ export interface SteerWakePayload {
   messageId: string
   conversationId: string
   authorName: string
+  authorId?: string
   body: string
   /** Tenant tag so the steer-ack typing broadcast routes to clients instead of
    *  being dropped as "untagged". Sourced from the message-new event. Optional
@@ -308,6 +310,14 @@ async function wakeOne(
     // managed-executor.ts, keyed by agentId.
     if (env.LINGXILOOP_MANAGED_AGENT_EXECUTION === 'server' && env.LINGXILOOP_REASONING_RUNTIME === 'lingxigraph') {
       const turnOptions: AgentTurnOptions = { trigger: reason, ...options }
+      if (steerPayload) {
+        const routed = await routeLingxiGraphSteering(agentId, steerPayload)
+        if (routed.handled) {
+          console.info(`[scheduler] message ${steerPayload.messageId} -> agent ${agentId} -> run ${routed.runId} -> steering ${routed.result?.eventId ?? routed.result?.outcome} (${routed.result?.outcome})`)
+          return
+        }
+        if (routed.runId) console.info(`[scheduler] run ${routed.runId} rejected/failed steering; message ${steerPayload.messageId} falls back to a new turn`)
+      }
       void scheduleManagedAgentTurn(agentId, turnOptions).catch((err) =>
         console.error(`[scheduler] scheduleManagedAgentTurn(${agentId}) failed:`,
           err instanceof Error ? err.message : String(err)),
@@ -562,7 +572,7 @@ async function wake(payload: MessageNewEvent): Promise<void> {
   let steerPayload: SteerWakePayload | null = null
   if (messageKind !== 'system' && messageBody && messageBody.length > 0) {
     const authorName = await resolveAuthorName(authorId)
-    steerPayload = { messageId, conversationId, authorName, body: messageBody, companyId: payload.companyId ?? '' }
+    steerPayload = { messageId, conversationId, authorId, authorName, body: messageBody, companyId: payload.companyId ?? '' }
   }
 
   const { rows: convoRows } = await pool.query<{ members: string[]; kind: string; leader_id: string | null; muted_agent_ids: string[] }>(

--- a/server/src/agents/turn.ts
+++ b/server/src/agents/turn.ts
@@ -2149,7 +2149,11 @@ ${peerWorkBlock}`.trim()
       data: { model, contextChars: contextPrompt.length }, stage: 'thinking',
     })
     const startedAt = Date.now()
-    const result = await runLingxiGraph({
+    const { registerActiveLingxiGraphRun, clearActiveLingxiGraphRun } = await import('./lingxigraph-active-runs.js')
+    registerActiveLingxiGraphRun({ runId, agentId, companyId: runCompanyId })
+    let result
+    try {
+      result = await runLingxiGraph({
       version: 1, runId,
       agent: { id: persona.id, name: persona.name, role: persona.role, model },
       trigger: options.trigger ?? 'message.new', systemPrompt: instructions, contextPrompt,
@@ -2157,7 +2161,10 @@ ${peerWorkBlock}`.trim()
       url: env.LINGXIGRAPH_URL,
       token: env.LINGXIGRAPH_TOKEN,
       timeoutMs: env.LINGXIGRAPH_RUN_TIMEOUT_MS,
-    })
+      })
+    } finally {
+      clearActiveLingxiGraphRun(agentId, runId)
+    }
     const elapsedMs = Date.now() - startedAt
     const perCallLatency = result.modelCalls.length > 0 ? Math.round(elapsedMs / result.modelCalls.length) : elapsedMs
     for (const call of result.modelCalls) {


### PR DESCRIPTION
## Summary

- route follow-up messages for active managed LingxiGraph runs through `/v1/runs/{run_id}/steer`
- use the stored Loop message ID as the stable steering idempotency key and enforce trusted agent/tenant/run routing
- distinguish accepted, duplicate, terminal, transient, and permanent outcomes without steer/new-turn double processing
- keep the legacy local steering queue isolated from the LingxiGraph server path
- document LingxiGraph as the canonical runtime steering owner

## Tests

- `npm run server:typecheck`
- `node --import tsx --experimental-test-module-mocks --test server/src/__tests__/agents-lingxigraph-adapter.test.ts server/src/__tests__/agents-lingxigraph-steering-router.test.ts server/src/__tests__/agents-managed-executor.test.ts`
- `OPENAI_API_KEY=test LINGXIGRAPH_URL=http://runtime.test node --import tsx --experimental-test-module-mocks --test server/src/__tests__/agents-scheduler-managed-routing.test.ts` (environment variables supplied using PowerShell syntax)

Closes #32