### PR TITLE
fix: propagate tenant across LingxiGraph native runs

### DIFF
--- a/server/src/__tests__/agents-lingxigraph-adapter.test.ts
+++ b/server/src/__tests__/agents-lingxigraph-adapter.test.ts
@@ -223,6 +223,7 @@ test('runtime adapter times out a response whose body never completes, even afte
 test('steering adapter sends a stable Idempotency-Key and parses durable acceptance', async () => {
   let seenUrl = ''
   let seenKey = ''
+  let seenTenant = ''
   let seenBody: unknown
   const accepted = await steerLingxiGraphRun({
     runId: 'run/trusted',
@@ -231,9 +232,11 @@ test('steering adapter sends a stable Idempotency-Key and parses durable accepta
     idempotencyKey: 'm-1',
   }, {
     url: 'http://runtime.local:8124',
+    tenantId: 'co-1',
     fetchImpl: fakeFetch((url, init) => {
       seenUrl = url
       seenKey = (init.headers as Record<string, string>)['idempotency-key']
+      seenTenant = (init.headers as Record<string, string>)['x-tenant-id']
       seenBody = JSON.parse(String(init.body))
       return new Response(JSON.stringify({
         id: 'steer-1', run_id: 'run/trusted', sequence: 3,
@@ -243,11 +246,31 @@ test('steering adapter sends a stable Idempotency-Key and parses durable accepta
   })
   assert.equal(seenUrl, 'http://runtime.local:8124/v1/runs/run%2Ftrusted/steer')
   assert.equal(seenKey, 'm-1')
+  assert.equal(seenTenant, 'co-1')
   assert.deepEqual(seenBody, { kind: 'message.new', payload: { messageId: 'm-1', body: 'follow up' }, metadata: {} })
   assert.deepEqual(accepted, {
     outcome: 'accepted', eventId: 'steer-1', runId: 'run/trusted', sequence: 3,
     status: 'pending', kind: 'message.new',
   })
+})
+
+test('native Runtime requests keep bearer authentication free of dev tenant headers', async () => {
+  let headers: Record<string, string> | undefined
+  await steerLingxiGraphRun({
+    runId: 'r1', kind: 'message.new', payload: {}, idempotencyKey: 'm-1',
+  }, {
+    url: 'http://runtime.local:8124',
+    token: 'production-token',
+    tenantId: 'co-1',
+    fetchImpl: fakeFetch((_url, init) => {
+      headers = init.headers as Record<string, string>
+      return new Response(JSON.stringify({
+        id: 's1', run_id: 'r1', sequence: 1, status: 'pending', kind: 'message.new',
+      }), { status: 202 })
+    }),
+  })
+  assert.equal(headers?.authorization, 'Bearer production-token')
+  assert.equal(headers?.['x-tenant-id'], undefined)
 })
 
 test('steering adapter classifies terminal/finalizing rejection as permanent', async () => {
@@ -294,22 +317,42 @@ test('native SSE adapter resumes from Last-Event-ID and deduplicates sequences',
     },
   })
   let lastEventId = ''
+  let tenant = ''
   const events: string[] = []
   const cursor = await streamLingxiGraphRunEvents('r1', (event) => { events.push(event.kind) }, {
     url: 'http://runtime.local:8124',
+    tenantId: 'co-1',
     lastEventId: 8,
     fetchImpl: fakeFetch((_url, init) => {
       lastEventId = (init.headers as Record<string, string>)['last-event-id']
+      tenant = (init.headers as Record<string, string>)['x-tenant-id']
       return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
     }),
   })
   assert.equal(lastEventId, '8')
+  assert.equal(tenant, 'co-1')
   assert.deepEqual(events, ['run.steer.consumed'])
   assert.equal(cursor, 9)
 })
 
+test('omitting an insecure-dev tenant resolves the stream under default and reproduces run-not-found', async () => {
+  let resolvedTenant = ''
+  await assert.rejects(streamLingxiGraphRunEvents('run-owned-by-co-1', () => undefined, {
+    url: 'http://runtime.local:8124',
+    fetchImpl: fakeFetch((_url, init) => {
+      resolvedTenant = (init.headers as Record<string, string>)['x-tenant-id'] ?? 'default'
+      return new Response('run not found', { status: 404 })
+    }),
+  }), (error: unknown) => error instanceof LingxiGraphRequestError
+    && error.status === 404
+    && /run not found/.test(error.message))
+  assert.equal(resolvedTenant, 'default')
+  assert.notEqual(resolvedTenant, 'co-1')
+})
+
 test('native run adapter creates a Runtime run, consumes SSE, and reads authoritative output', async () => {
   const urls: string[] = []
+  const tenants: Array<{ url: string; tenant: string | undefined }> = []
   const events: string[] = []
   let runKey = ''
   let tenant = ''
@@ -320,7 +363,9 @@ test('native run adapter creates a Runtime run, consumes SSE, and reads authorit
     onRunEvent: (event) => { events.push(event.kind) },
     fetchImpl: fakeFetch((url, init) => {
       urls.push(url)
-      tenant = (init.headers as Record<string, string> | undefined)?.['x-tenant-id'] ?? tenant
+      const requestTenant = (init.headers as Record<string, string> | undefined)?.['x-tenant-id']
+      tenant = requestTenant ?? tenant
+      tenants.push({ url, tenant: requestTenant })
       if (url.endsWith('/v1/assistants') && !init.method) return new Response('[]', { status: 200 })
       if (url.endsWith('/v1/assistants')) return new Response(JSON.stringify({ id: 'assistant-1' }), { status: 201 })
       if (url.endsWith('/v1/runs')) {
@@ -347,6 +392,16 @@ test('native run adapter creates a Runtime run, consumes SSE, and reads authorit
   assert.equal(runKey, 'lingxiloop-run:r1')
   assert.deepEqual(events, ['run_completed'])
   assert.equal(urls.some((url) => url.endsWith('/v1/runs/runtime-run-1/stream')), true)
+  assert.deepEqual(tenants.map(({ url, tenant }) => ({
+    path: new URL(url).pathname,
+    tenant,
+  })), [
+    { path: '/v1/assistants', tenant: 'co-1' },
+    { path: '/v1/assistants', tenant: 'co-1' },
+    { path: '/v1/runs', tenant: 'co-1' },
+    { path: '/v1/runs/runtime-run-1/stream', tenant: 'co-1' },
+    { path: '/v1/runs/runtime-run-1', tenant: 'co-1' },
+  ])
 })
 
 /* ─── issue #7: action idempotency key generation ────────────────────── */

--- a/server/src/agents/lingxigraph-adapter.ts
+++ b/server/src/agents/lingxigraph-adapter.ts
@@ -142,7 +142,7 @@ export async function getLingxiGraphRun(
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
     const response = await (options.fetchImpl ?? fetch)(new URL(`/v1/runs/${encodeURIComponent(runId)}`, baseUrl), {
-      headers: graphHeaders(token, !token && tenantId ? { 'x-tenant-id': tenantId } : {}),
+      headers: runtimeHeaders(token, tenantId),
       signal: controller.signal,
     })
     const raw = await response.text()
@@ -168,11 +168,23 @@ function graphHeaders(token: string | undefined, extra: Record<string, string> =
   }
 }
 
-function tenantHeaders(request: LingxiGraphRunRequest, token: string | undefined): Record<string, string> {
+/**
+ * Build Runtime headers for a single tenant. Production identity comes from a
+ * verified bearer token; the explicit tenant header is deliberately limited
+ * to the Runtime's insecure development auth mode.
+ */
+function runtimeHeaders(
+  token: string | undefined,
+  tenantId: string | null | undefined,
+  extra: Record<string, string> = {},
+): Record<string, string> {
   // Production tenant identity comes exclusively from the verified JWT. The
   // explicit header is only valid when no bearer token is configured (the
   // official Runtime's controlled insecure-dev mode).
-  return !token && request.tenantId ? { 'x-tenant-id': request.tenantId } : {}
+  return graphHeaders(token, {
+    ...(!token && tenantId ? { 'x-tenant-id': tenantId } : {}),
+    ...extra,
+  })
 }
 
 function problemDetails(raw: string, fallbackCode: string): { code: string; detail: string; retryable?: boolean } {
@@ -224,7 +236,7 @@ export async function steerLingxiGraphRun(
     try {
       const response = await doFetch(new URL(`/v1/runs/${encodeURIComponent(request.runId)}/steer`, baseUrl), {
         method: 'POST',
-        headers: graphHeaders(token, {
+        headers: runtimeHeaders(token, options.tenantId, {
           'content-type': 'application/json',
           'idempotency-key': request.idempotencyKey,
         }),
@@ -289,8 +301,7 @@ export async function streamLingxiGraphRunEvents(
   if (!baseUrl) throw new Error('LINGXIGRAPH_URL is required to reach the LingxiGraph runtime')
   const token = options.token ?? process.env.LINGXIGRAPH_TOKEN
   const response = await (options.fetchImpl ?? fetch)(new URL(`/v1/runs/${encodeURIComponent(runId)}/stream`, baseUrl), {
-    headers: graphHeaders(token, {
-      ...(!token && options.tenantId ? { 'x-tenant-id': options.tenantId } : {}),
+    headers: runtimeHeaders(token, options.tenantId, {
       accept: 'text/event-stream',
       ...(options.lastEventId ? { 'last-event-id': String(options.lastEventId) } : {}),
     }),
@@ -740,10 +751,7 @@ async function runLingxiGraphNative(
   const originalFetch = options.fetchImpl ?? fetch
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
-  const headers = (extra: Record<string, string> = {}) => graphHeaders(token, {
-    ...tenantHeaders(request, token),
-    ...extra,
-  })
+  const headers = (extra: Record<string, string> = {}) => runtimeHeaders(token, request.tenantId, extra)
   const doFetch: typeof fetch = ((input: Parameters<typeof fetch>[0], init?: RequestInit) => originalFetch(input, {
     ...init,
     signal: controller.signal,
@@ -818,7 +826,7 @@ async function runLingxiGraphNative(
       } else if (channel === 'message.reset') {
         await options.onMessageReset?.()
       }
-    }, { url: baseUrl, token, fetchImpl: doFetch })
+    }, { url: baseUrl, token, fetchImpl: doFetch, tenantId: request.tenantId ?? null })
 
     const finalRun = await readJson(await doFetch(new URL(`/v1/runs/${encodeURIComponent(runtimeRunId)}`, baseUrl), {
       headers: headers(),

--- a/server/src/agents/managed-executor.ts
+++ b/server/src/agents/managed-executor.ts
@@ -271,6 +271,7 @@ export async function scheduleManagedAgentTurn(
         const run = await runLookup(recovered.runtimeRunId, recovered.companyId, {
           url: env.LINGXIGRAPH_URL,
           token: env.LINGXIGRAPH_TOKEN,
+          tenantId: recovered.companyId,
         })
         state.lastSteeredMessageId = null
         state.activeRun = { runId: run.id, loopRunId: recovered.loopRunId, companyId: recovered.companyId }
@@ -340,6 +341,7 @@ export async function scheduleManagedAgentTurn(
           }, {
             url: env.LINGXIGRAPH_URL,
             token: env.LINGXIGRAPH_TOKEN,
+            tenantId: active.companyId,
           })
           if (accepted.status !== 'consumed' && accepted.status !== 'superseded') {
             state.pendingSteers.set(accepted.eventId, steerPayload)


### PR DESCRIPTION
## Summary
- Propagate tenant identity across native Runtime stream, steer, and recovery get requests.
- Centralize native Runtime authorization and insecure-dev tenant headers.
- Add regressions for full native lifecycle, steering, bearer auth, and omitted-tenant 404 behavior.

## Validation
- 
px tsx --test server/src/__tests__/agents-lingxigraph-adapter.test.ts (26 passed)

Fixes #43