### PR TITLE
fix(im): restore protocol negotiation in MVP

### DIFF
--- a/docker-compose.mvp.yml
+++ b/docker-compose.mvp.yml
@@ -112,6 +112,7 @@ services:
       WUKONG_WS_URL: ${WUKONG_WS_URL:-ws://localhost:5200}
       WUKONG_API_TOKEN: ${WUKONG_API_TOKEN:-dev-wukong-api-token}
       WUKONG_WEBHOOK_SECRET: ${WUKONG_WEBHOOK_SECRET:-dev-wukong-webhook-secret}
+      WUKONG_USER_TOKEN_SECRET: ${WUKONG_USER_TOKEN_SECRET:?WUKONG_USER_TOKEN_SECRET is required in .env}
       WUKONG_WEBHOOK_ALLOW_UNSIGNED_INTERNAL: "true"
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?DEEPSEEK_API_KEY is required in .env}
       DEEPSEEK_BASE_URL: ${DEEPSEEK_BASE_URL:-https://api.deepseek.com/v1}

--- a/server/src/__tests__/wukong-client.test.ts
+++ b/server/src/__tests__/wukong-client.test.ts
@@ -58,6 +58,13 @@ test('WuKong adapter syncs channel history and decodes Lingxi payloads', async (
   assert.equal(messages[0]?.clientMsgNo, 'client-9')
 })
 
+test('WuKong adapter treats missing empty-channel sync state as empty results', async () => {
+  globalThis.fetch = async () => new Response('messagesync not found', { status: 404 })
+  const client = new WukongClient({ apiUrl: 'http://wk', wsUrl: 'ws://wk', apiToken: 'token', webhookSecret: 'secret' })
+  assert.deepEqual(await client.syncMessages('empty', 2), [])
+  await assert.doesNotReject(client.clearUnread('student', 'empty', 2))
+})
+
 test('WuKong stream events include enough routing metadata for the browser', async () => {
   let body: Record<string, unknown> = {}
   globalThis.fetch = async (_input, init) => {

--- a/server/src/im/wukong.ts
+++ b/server/src/im/wukong.ts
@@ -13,6 +13,10 @@ function jsonRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && /returned 404(?:\D|$)/.test(error.message)
+}
+
 export class WukongClient {
   constructor(readonly config: WukongConfig) {}
 
@@ -134,15 +138,27 @@ export class WukongClient {
   }
 
   async clearUnread(uid: string, channelId: string, channelType: number): Promise<void> {
-    await this.request('/conversations/clearUnread', {
-      method: 'POST', body: JSON.stringify({ uid, channel_id: channelId, channel_type: channelType }),
-    })
+    try {
+      await this.request('/conversations/clearUnread', {
+        method: 'POST', body: JSON.stringify({ uid, channel_id: channelId, channel_type: channelType }),
+      })
+    } catch (error) {
+      // WuKongIM has no conversation to clear until a channel receives a message.
+      if (!isNotFound(error)) throw error
+    }
   }
 
   async syncMessages(channelId: string, channelType: number, limit = 80, loginUid = ''): Promise<ImMessage[]> {
-    const value = await this.request<unknown>('/channel/messagesync', {
-      method: 'POST', body: JSON.stringify({ login_uid: loginUid, channel_id: channelId, channel_type: channelType, start_message_seq: 0, end_message_seq: 0, limit, pull_mode: 1 }),
-    })
+    let value: unknown
+    try {
+      value = await this.request<unknown>('/channel/messagesync', {
+        method: 'POST', body: JSON.stringify({ login_uid: loginUid, channel_id: channelId, channel_type: channelType, start_message_seq: 0, end_message_seq: 0, limit, pull_mode: 1 }),
+      })
+    } catch (error) {
+      // An empty channel has no sync state yet; expose it as an empty history.
+      if (isNotFound(error)) return []
+      throw error
+    }
     const root = jsonRecord(value)
     const list = Array.isArray(value) ? value : Array.isArray(root.messages) ? root.messages : []
     return list.map((raw) => {

--- a/src/lib/im/wukong.ts
+++ b/src/lib/im/wukong.ts
@@ -1,6 +1,6 @@
-import WKSDK, { MessageContent, type Message as WKMessage, type WKEvent } from 'wukongimjssdk'
-import { getAuthToken, getActiveCompanyId } from '@/stores/auth'
+import WKSDK, { MessageContent, type WKEvent, type Message as WKMessage } from 'wukongimjssdk'
 import { getServerOrigin } from '@/api/client'
+import { getActiveCompanyId, getAuthToken } from '@/stores/auth'
 
 export const LINGXI_MESSAGE_CONTENT_TYPE = 1000
 
@@ -119,7 +119,6 @@ export class LingxiImClient {
     this.sdk.config.uid = bootstrap.uid
     this.sdk.config.token = bootstrap.token
     this.sdk.config.addr = bootstrap.wsUrl
-    this.sdk.config.protoVersion = 3
     this.sdk.connect()
     this.started = true
   }


### PR DESCRIPTION
## Summary
- 移除浏览器端对 `protoVersion = 3` 的覆盖，让 `wukongimjssdk@1.3.5` 与 WuKongIM 自行协商协议版本。
- 向 MVP 的 `lingxiloop` 容器显式、必填地传递 `WUKONG_USER_TOKEN_SECRET`，避免回退到 `AGENT_OS_SERVICE_TOKEN`。
- 将空频道的 WuKongIM 404 视为无消息/无需清未读，并新增回归测试；其余错误继续向上抛出。

## Validation
- `npm exec -- biome check src/lib/im/wukong.ts server/src/im/wukong.ts server/src/__tests__/wukong-client.test.ts`
- `npm exec -- tsx --test server/src/__tests__/wukong-client.test.ts`
- `docker compose -f docker-compose.mvp.yml config --quiet`

Closes #47