### PR TITLE
fix(chat): handle empty IM history and pin composer

### DIFF
--- a/server/src/__tests__/wukong-client.test.ts
+++ b/server/src/__tests__/wukong-client.test.ts
@@ -65,6 +65,13 @@ test('WuKong adapter treats missing empty-channel sync state as empty results', 
   await assert.doesNotReject(client.clearUnread('student', 'empty', 2))
 })
 
+test('WuKong adapter treats the empty-channel 500 response as empty results', async () => {
+  globalThis.fetch = async () => new Response('messagesync not found', { status: 500 })
+  const client = new WukongClient({ apiUrl: 'http://wk', wsUrl: 'ws://wk', apiToken: 'token', webhookSecret: 'secret' })
+  assert.deepEqual(await client.syncMessages('empty', 2), [])
+  await assert.doesNotReject(client.clearUnread('student', 'empty', 2))
+})
+
 test('WuKong stream events include enough routing metadata for the browser', async () => {
   let body: Record<string, unknown> = {}
   globalThis.fetch = async (_input, init) => {

--- a/server/src/im/wukong.ts
+++ b/server/src/im/wukong.ts
@@ -13,8 +13,14 @@ function jsonRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-function isNotFound(error: unknown): boolean {
-  return error instanceof Error && /returned 404(?:\D|$)/.test(error.message)
+function isEmptyChannelResult(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  // WuKongIM reports a newly-created channel with no sync/conversation state
+  // as either a conventional 404 or a 500 whose response says "not found".
+  // Both mean the same thing to the chat UI: there is simply no history (or
+  // unread state) to return yet. Do not hide unrelated 500 failures.
+  return /returned 404(?:\D|$)/.test(error.message)
+    || (/returned 500(?:\D|$)/.test(error.message) && /not found/i.test(error.message))
 }
 
 export class WukongClient {
@@ -144,7 +150,7 @@ export class WukongClient {
       })
     } catch (error) {
       // WuKongIM has no conversation to clear until a channel receives a message.
-      if (!isNotFound(error)) throw error
+      if (!isEmptyChannelResult(error)) throw error
     }
   }
 
@@ -156,7 +162,7 @@ export class WukongClient {
       })
     } catch (error) {
       // An empty channel has no sync state yet; expose it as an empty history.
-      if (isNotFound(error)) return []
+      if (isEmptyChannelResult(error)) return []
       throw error
     }
     const root = jsonRecord(value)

--- a/src/desktop/ChatPane.tsx
+++ b/src/desktop/ChatPane.tsx
@@ -1952,7 +1952,7 @@ export function ChatPane() {
   return (
     <main
       className={cn(
-        'chat-surface grid overflow-hidden',
+        'chat-surface grid h-full min-h-0 min-w-0 overflow-hidden',
         searchOpen
           ? 'grid-rows-[auto_auto_auto_minmax(0,1fr)_auto]'
           : 'grid-rows-[auto_auto_minmax(0,1fr)_auto]',

--- a/src/lib/messageShell.test.ts
+++ b/src/lib/messageShell.test.ts
@@ -23,6 +23,13 @@ test('desktop and mobile both render the shared MessageRow component', async () 
   assert.match(mobile, /<MessageRow\b/)
 })
 
+test('desktop chat reserves a scrollable middle row so the composer stays at the bottom', async () => {
+  const desktop = await readFile(new URL('../desktop/ChatPane.tsx', import.meta.url), 'utf8')
+  assert.match(desktop, /chat-surface grid h-full min-h-0 min-w-0 overflow-hidden/)
+  assert.match(desktop, /grid-rows-\[auto_auto_minmax\(0,1fr\)_auto\]/)
+  assert.match(desktop, /<Composer convoId=\{convoId\} \/>/)
+})
+
 test('Coworker cards use semantic light/dark tokens and expose the shared shell marker', async () => {
   const message = await readFile(new URL('../components/Message.tsx', import.meta.url), 'utf8')
   const activity = await readFile(new URL('../desktop/ChatPane.tsx', import.meta.url), 'utf8')


### PR DESCRIPTION
## Summary
- Treat WuKongIM's documented empty-channel `not found` 500 response as an empty message history/unread state, while preserving unrelated 500 failures.
- Give the desktop chat grid a definite, shrinkable height so the virtualized message area owns the middle row and the composer remains at the bottom.
- Add regressions for the empty-channel 500 response and the chat grid contract.

## Validation
- `npm exec -- biome check server/src/im/wukong.ts server/src/__tests__/wukong-client.test.ts src/desktop/ChatPane.tsx src/lib/messageShell.test.ts`
- `npm exec -- tsx --test server/src/__tests__/wukong-client.test.ts`
- `npm exec -- tsx --test src/lib/messageShell.test.ts`

Closes #49