### PR TITLE
fix(agent-os): handle OpenAI-compatible gateway streams

### DIFF
--- a/server/src/__tests__/agent-os-model-driver.test.ts
+++ b/server/src/__tests__/agent-os-model-driver.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { test } from 'node:test'
+import { DeepSeekChatDriver, ModelAdapterError } from '../agent-os/model-driver.js'
+
+async function withGateway(
+  events: unknown[],
+  run: (baseURL: string, requestBody: Record<string, unknown>) => Promise<void>,
+): Promise<void> {
+  const requestBody: Record<string, unknown> = {}
+  const server = createServer((request, response) => {
+    const body: Buffer[] = []
+    request.on('data', (chunk: Buffer) => body.push(chunk))
+    request.on('end', () => {
+      Object.assign(requestBody, JSON.parse(Buffer.concat(body).toString()) as Record<string, unknown>)
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      for (const event of events) response.write(`data: ${JSON.stringify(event)}\n\n`)
+      response.end('data: [DONE]\n\n')
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const address = server.address()
+    assert.ok(address && typeof address === 'object')
+    await run(`http://127.0.0.1:${address.port}/v1`, requestBody)
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
+}
+
+test('OpenAI-compatible stream parses complete message envelopes and marks missing usage', async () => {
+  const events = [{
+    id: 'chatcmpl-compatible', object: 'chat.completion.chunk', created: 1, model: 'compatible',
+    choices: [{ index: 0, message: { role: 'assistant', content: 'Gateway reply' }, finish_reason: 'stop' }],
+  }]
+  await withGateway(events, async (baseURL, requestBody) => {
+    const driver = new DeepSeekChatDriver('compatible', { apiKey: 'test', baseURL })
+    const result = await driver.run({ instructions: 'System prompt', items: [{ role: 'user', content: 'Hello' }] })
+    assert.equal(result.text, 'Gateway reply')
+    assert.deepEqual(result.output, [{ role: 'assistant', content: 'Gateway reply' }])
+    assert.equal(result.usage.available, false)
+    assert.deepEqual(result.diagnostics?.finishReasons, ['stop'])
+    assert.equal(requestBody.stream, true)
+    assert.ok(Array.isArray(requestBody.tools))
+  })
+})
+
+test('empty compatible stream throws an explicit adapter error with parse diagnostics', async () => {
+  const events = [{
+    id: 'chatcmpl-empty', object: 'chat.completion.chunk', created: 1, model: 'compatible',
+    choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: 'stop' }],
+  }]
+  await withGateway(events, async (baseURL) => {
+    const driver = new DeepSeekChatDriver('compatible', { apiKey: 'test', baseURL })
+    await assert.rejects(
+      driver.run({ instructions: 'System prompt', items: [{ role: 'user', content: 'Hello' }] }),
+      (error: unknown) => {
+        assert.ok(error instanceof ModelAdapterError)
+        assert.match(error.message, /no assistant content or supported tool calls/)
+        assert.equal(error.diagnostics.chunkCount, 1)
+        assert.deepEqual(error.diagnostics.finishReasons, ['stop'])
+        assert.match(error.diagnostics.chunkShapes[0] ?? '', /deltaKeys/)
+        return true
+      },
+    )
+  })
+})

--- a/server/src/__tests__/agent-os-runtime.test.ts
+++ b/server/src/__tests__/agent-os-runtime.test.ts
@@ -100,8 +100,10 @@ test('an empty model response fails once with adapter diagnostics, not a hop-lim
   const started = host.events.filter((event) => event.kind === 'model.started')
   const failed = host.events.find((event) => event.kind === 'run.failed')
   assert.equal(started.length, 1)
-  assert.match(String(failed?.data.error), /no assistant content/)
-  assert.deepEqual(failed?.data.modelDiagnostics, diagnostics)
+  assert.ok(failed?.data && typeof failed.data === 'object')
+  const failedData = failed.data as Record<string, unknown>
+  assert.match(String(failedData.error), /no assistant content/)
+  assert.deepEqual(failedData.modelDiagnostics, diagnostics)
   assert.doesNotMatch(String(host.outcomes.get(item.id)?.error), /model hops/)
 })
 

--- a/server/src/__tests__/agent-os-runtime.test.ts
+++ b/server/src/__tests__/agent-os-runtime.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { MemoryHostAdapter } from '../agent-os/host-adapter.js'
 import type { KernelExecutor } from '../agent-os/kernel-manager.js'
-import { ScriptedModelDriver, type AgentModelDriver, type ModelTurnResult } from '../agent-os/model-driver.js'
+import { type AgentModelDriver, ModelAdapterError, type ModelTurnResult, ScriptedModelDriver } from '../agent-os/model-driver.js'
 import { AgentOSRuntime, canvasContextContract } from '../agent-os/runtime.js'
 import type { AgentContext, AgentWorkItem, KernelExecution, ModelItem } from '../agent-os/types.js'
 
@@ -84,6 +84,25 @@ test('Agent OS runs multi-hop IPython and keeps the channel session across work 
   assert.ok(history.some((item) => 'type' in item && item.type === 'function_call_output'))
   assert.equal(host.outcomes.get(first.id)?.status, 'completed')
   assert.equal(host.outcomes.get(second.id)?.status, 'completed')
+})
+
+test('an empty model response fails once with adapter diagnostics, not a hop-limit error', async () => {
+  const item = work('empty-model', 'm-empty')
+  const host = new MemoryHostAdapter()
+  host.contexts.set(item.id, context(item, 'Hello?'))
+  const diagnostics = { chunkCount: 1, choiceCount: 1, finishReasons: ['stop'], contentLength: 0, toolCallCount: 0, chunkShapes: ['{"deltaKeys":["role"]}'] }
+  const model: AgentModelDriver = {
+    run: async () => { throw new ModelAdapterError('model returned no assistant content or supported tool calls', diagnostics) },
+    compact: async () => '',
+    structured: async () => ({}),
+  }
+  await new AgentOSRuntime(host, model, new StatefulKernel(), { heartbeatMs: 60_000 }).runWork(item)
+  const started = host.events.filter((event) => event.kind === 'model.started')
+  const failed = host.events.find((event) => event.kind === 'run.failed')
+  assert.equal(started.length, 1)
+  assert.match(String(failed?.data.error), /no assistant content/)
+  assert.deepEqual(failed?.data.modelDiagnostics, diagnostics)
+  assert.doesNotMatch(String(host.outcomes.get(item.id)?.error), /model hops/)
 })
 
 test('PromptContext stays frozen within one compaction epoch', async () => {

--- a/server/src/agent-os/model-driver.ts
+++ b/server/src/agent-os/model-driver.ts
@@ -114,7 +114,7 @@ export class DeepSeekChatDriver implements AgentModelDriver {
         if (choice.finish_reason) finishReasons.add(choice.finish_reason)
         const compatible = choice as unknown as {
           delta?: { content?: string | null; tool_calls?: Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }> }
-          message?: { content?: string | null; tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> }
+          message?: { content?: string | null; tool_calls?: Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }> }
         }
         const content = compatible.delta?.content ?? compatible.message?.content
         if (content) {

--- a/server/src/agent-os/model-driver.ts
+++ b/server/src/agent-os/model-driver.ts
@@ -6,7 +6,24 @@ import type { ModelItem } from './types.js'
 export type ModelTurnResult = {
   output: ModelItem[]
   text: string
-  usage: { inputTokens: number; outputTokens: number }
+  usage: { inputTokens: number; outputTokens: number; available?: boolean }
+  diagnostics?: ModelTurnDiagnostics
+}
+
+export type ModelTurnDiagnostics = {
+  chunkCount: number
+  choiceCount: number
+  finishReasons: string[]
+  contentLength: number
+  toolCallCount: number
+  chunkShapes: string[]
+}
+
+export class ModelAdapterError extends Error {
+  constructor(message: string, readonly diagnostics: ModelTurnDiagnostics) {
+    super(message)
+    this.name = 'ModelAdapterError'
+  }
 }
 
 export interface AgentModelDriver {
@@ -66,24 +83,53 @@ export class DeepSeekChatDriver implements AgentModelDriver {
     let text = ''
     let inputTokens = 0
     let outputTokens = 0
+    let usageAvailable = false
+    let chunkCount = 0
+    let choiceCount = 0
+    const finishReasons = new Set<string>()
+    const chunkShapes: string[] = []
     const calls = new Map<number, { id: string; name: string; arguments: string }>()
     for await (const chunk of stream) {
+      chunkCount += 1
+      choiceCount += chunk.choices.length
+      if (chunkShapes.length < 8) {
+        chunkShapes.push(JSON.stringify({
+          keys: Object.keys(chunk),
+          choices: chunk.choices.map((choice) => ({
+            keys: Object.keys(choice),
+            deltaKeys: choice.delta ? Object.keys(choice.delta) : [],
+            // A few compatible gateways put a complete message in each SSE
+            // event instead of using OpenAI's delta envelope.
+            messageKeys: Object.keys((choice as unknown as { message?: object }).message ?? {}),
+            finishReason: choice.finish_reason ?? null,
+          })),
+        }))
+      }
       if (chunk.usage) {
+        usageAvailable = true
         inputTokens = chunk.usage.prompt_tokens ?? 0
         outputTokens = chunk.usage.completion_tokens ?? 0
       }
-      const delta = chunk.choices[0]?.delta
-      if (!delta) continue
-      if (delta.content) {
-        text += delta.content
-        await args.onTextDelta?.(delta.content)
-      }
-      for (const raw of delta.tool_calls ?? []) {
-        const existing = calls.get(raw.index) ?? { id: '', name: '', arguments: '' }
-        if (raw.id) existing.id = raw.id
-        if (raw.function?.name) existing.name += raw.function.name
-        if (raw.function?.arguments) existing.arguments += raw.function.arguments
-        calls.set(raw.index, existing)
+      for (const choice of chunk.choices) {
+        if (choice.finish_reason) finishReasons.add(choice.finish_reason)
+        const compatible = choice as unknown as {
+          delta?: { content?: string | null; tool_calls?: Array<{ index?: number; id?: string; function?: { name?: string; arguments?: string } }> }
+          message?: { content?: string | null; tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> }
+        }
+        const content = compatible.delta?.content ?? compatible.message?.content
+        if (content) {
+          text += content
+          await args.onTextDelta?.(content)
+        }
+        const rawCalls = compatible.delta?.tool_calls ?? compatible.message?.tool_calls ?? []
+        for (const [position, raw] of rawCalls.entries()) {
+          const index = raw.index ?? position
+          const existing = calls.get(index) ?? { id: '', name: '', arguments: '' }
+          if (raw.id) existing.id = raw.id
+          if (raw.function?.name) existing.name += raw.function.name
+          if (raw.function?.arguments) existing.arguments += raw.function.arguments
+          calls.set(index, existing)
+        }
       }
     }
     if (text) output.push({ role: 'assistant', content: text })
@@ -92,10 +138,25 @@ export class DeepSeekChatDriver implements AgentModelDriver {
         output.push({ type: 'function_call', callId: call.id, name: 'ipython', arguments: call.arguments })
       }
     }
+    const diagnostics: ModelTurnDiagnostics = {
+      chunkCount,
+      choiceCount,
+      finishReasons: [...finishReasons],
+      contentLength: text.length,
+      toolCallCount: output.filter((item) => 'type' in item && item.type === 'function_call').length,
+      chunkShapes,
+    }
+    if (output.length === 0) {
+      throw new ModelAdapterError(
+        `model returned no assistant content or supported tool calls (chunks=${chunkCount}, choices=${choiceCount}, finishReasons=${diagnostics.finishReasons.join(',') || 'unavailable'})`,
+        diagnostics,
+      )
+    }
     return {
       output,
       text,
-      usage: { inputTokens, outputTokens },
+      usage: { inputTokens, outputTokens, available: usageAvailable },
+      diagnostics,
     }
   }
 

--- a/server/src/agent-os/runtime.ts
+++ b/server/src/agent-os/runtime.ts
@@ -5,7 +5,7 @@ import {
   type KernelExecutor,
   KernelTimeoutError,
 } from './kernel-manager.js'
-import type { AgentModelDriver } from './model-driver.js'
+import { type AgentModelDriver, ModelAdapterError } from './model-driver.js'
 import { parseIPythonArguments } from './tool.js'
 import type { AgentRunEvent, AgentSessionRecord, AgentWorkItem, LingxiMessageV1, MemorySynthesisChange, ModelItem, PromptContextV1 } from './types.js'
 
@@ -191,7 +191,11 @@ export class AgentOSRuntime {
         session.history.push(...turn.output)
         await this.event(work, runId, {
           kind: 'model.completed', stage: 'completed', visibility: 'internal',
-          data: { hop: hop + 1, usage: turn.usage },
+          data: {
+            hop: hop + 1,
+            usage: turn.usage.available === false ? { available: false } : turn.usage,
+            ...(turn.diagnostics ? { diagnostics: turn.diagnostics } : {}),
+          },
         })
         const calls = turn.output.filter((item): item is Extract<ModelItem, { type: 'function_call' }> => 'type' in item && item.type === 'function_call')
         if (calls.length === 0) {
@@ -248,7 +252,7 @@ export class AgentOSRuntime {
             : session.promptContext
         }
       }
-      if (!finalText) throw new Error(`agent did not finish within ${this.options.maxHops} model hops`)
+      if (!finalText) throw new Error(`agent exhausted ${this.options.maxHops} model hops without a final assistant response`)
       if (work.reason !== 'canvas_worker') await this.host.commitMessage(work, messagePayload(work, finalText, runId))
       if ((work.reason === 'message' || work.reason === 'mention') && context.learnerId) {
         const trigger = context.messages.find((message) => message.clientMsgNo === work.triggerClientMsgNo)
@@ -268,7 +272,10 @@ export class AgentOSRuntime {
       const status = cancelled ? 'cancelled' : 'failed'
       await this.event(work, runId, {
         kind: cancelled ? 'run.cancelled' : 'run.failed', stage: status, visibility: 'user',
-        data: { error: error instanceof Error ? error.message : String(error) },
+        data: {
+          error: error instanceof Error ? error.message : String(error),
+          ...(error instanceof ModelAdapterError ? { modelDiagnostics: error.diagnostics } : {}),
+        },
       }).catch(() => undefined)
       await this.host.completeWork(work, { status, error: error instanceof Error ? error.message : String(error) })
     } finally {


### PR DESCRIPTION
## Summary
- parse every streamed choice and support OpenAI-compatible SSE events that carry a complete `message` envelope instead of `delta`
- reject empty assistant/tool responses immediately with bounded chunk-shape and finish-reason diagnostics
- distinguish unavailable usage from a real `0/0` usage report and attach turn diagnostics to model events
- report a genuine max-hop exhaustion separately from a first-hop adapter failure
- add gateway-level SSE regression tests and runtime failure coverage

## Verification
- `npm run server:typecheck`
- `npx biome check server/src/agent-os/model-driver.ts server/src/agent-os/runtime.ts server/src/__tests__/agent-os-model-driver.test.ts server/src/__tests__/agent-os-runtime.test.ts`
- `npm test` (226 passed)

Fixes #58