### PR TITLE
fix(im): repair mentions, streaming replies, and read state

### DIFF
--- a/server/src/__tests__/mentions.test.ts
+++ b/server/src/__tests__/mentions.test.ts
@@ -23,6 +23,11 @@ test('recognizes standalone @all without prefix collisions', () => {
   })
 })
 
+test('recognizes broadcast mentions next to CJK prose and legacy @everyone', () => {
+  assert.equal(parseMentions('请@all 都回答', targets).mentionAll, true)
+  assert.equal(parseMentions('@everyone please answer', targets).mentionAll, true)
+})
+
 test('ignores emails, URLs, inline code and fenced code', () => {
   const body = 'mail a@ann.com https://x.test/@anna `@iris-01`\n```ts\n@小灵\n```\nreal @human-1'
   assert.deepEqual(parseMentions(body, targets), {

--- a/server/src/im/webhook.ts
+++ b/server/src/im/webhook.ts
@@ -1,7 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto'
-import express, { Router, type Request, type Response, type NextFunction } from 'express'
-import { pool } from '../db/pool.js'
+import express, { type NextFunction, type Request, type Response, Router } from 'express'
 import type { LingxiMessageV1 } from '../agent-os/types.js'
+import { pool } from '../db/pool.js'
+import { parseMentions } from '../mentions.js'
 import { resolveLearningAgentRecipients } from './routing.js'
 import { wukongClient } from './wukong.js'
 
@@ -106,27 +107,32 @@ wukongWebhookRouter.post('/', safe(async (req, res) => {
       throw Object.assign(new Error('WuKong channel is not bound yet; retry webhook'), { status: 503 })
     }
     const profileMembers = Array.isArray(bindings[0].profile.members) ? bindings[0].profile.members.map(String) : []
-    const { rows: members } = await client.query<{ id: string; kind: 'human' | 'agent'; preset_key: string | null }>(
-      `SELECT id, kind, preset_key FROM participants WHERE company_id=$1 AND id=ANY($2::text[])`,
+    const { rows: members } = await client.query<{ id: string; name: string; kind: 'human' | 'agent'; preset_key: string | null }>(
+      `SELECT id, name, kind, preset_key FROM participants WHERE company_id=$1 AND id=ANY($2::text[])`,
       [bindings[0].company_id, profileMembers],
     )
     if (!members.some((member) => member.id === fromUid)) {
       throw new Error('message author is not a bound channel member')
     }
     const refs = payload.refs ?? {}
-    const mentionedIds = Array.isArray(payload.data?.mentionedIds) ? payload.data.mentionedIds.map(String) : []
+    const parsedMentions = parseMentions(payload.body ?? '', members)
+    const mentionedIds = [...new Set([
+      ...(Array.isArray(payload.data?.mentionedIds) ? payload.data.mentionedIds.map(String) : []),
+      ...parsedMentions.mentionedIds,
+    ])]
+    const mentionAll = payload.data?.mentionAll === true || parsedMentions.mentionAll
     const recipients = resolveLearningAgentRecipients({
           authorId: fromUid,
           channelType: Number(bindings[0].profile.channelType ?? 2),
           members: members.map((member) => ({ id: member.id, kind: member.kind, presetKey: member.preset_key })),
           mentionedIds,
-          mentionAll: payload.data?.mentionAll === true,
+          mentionAll,
           replyAuthorId: typeof payload.data?.replyAuthorId === 'string' ? payload.data.replyAuthorId : undefined,
           leaderAgentId: bindings[0].leader_agent_id ?? undefined,
           handoffTargetId: payload.kind === 'handoff' ? refs.toAgentId : undefined,
         })
     for (const agentId of recipients) {
-      const reason = payload.kind === 'handoff' ? 'handoff' : mentionedIds.includes(agentId) || payload.data?.mentionAll === true ? 'mention' : 'message'
+      const reason = payload.kind === 'handoff' ? 'handoff' : mentionedIds.includes(agentId) || mentionAll ? 'mention' : 'message'
       await client.query(
         `INSERT INTO agent_work_items
            (id, company_id, agent_id, channel_id, thread_root_client_msg_no, trigger_client_msg_no, reason)

--- a/server/src/mentions.ts
+++ b/server/src/mentions.ts
@@ -66,11 +66,12 @@ export function parseMentions(input: string, targets: MentionTarget[]): ParsedMe
     // preceding Chinese character as part of an identifier would miss it.
     if (prev && (/[A-Za-z0-9_]/.test(prev) || prev === '@')) continue
     const tail = text.slice(i + 1).join('').toLocaleLowerCase()
-    if (tail.startsWith('all')) {
-      const after = text[i + 4]
+    const broadcast = ['everyone', 'all'].find((token) => tail.startsWith(token))
+    if (broadcast) {
+      const after = text[i + 1 + broadcast.length]
       if (!after || !WORD.test(after)) {
         mentionAll = true
-        i += 3
+        i += broadcast.length - 1
         continue
       }
     }

--- a/src/components/RichInput.tsx
+++ b/src/components/RichInput.tsx
@@ -11,19 +11,19 @@
  * pre-contenteditable composer.
  */
 import {
+  type ClipboardEvent,
+  type CSSProperties,
   forwardRef,
+  type KeyboardEvent,
   useCallback,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
-  type CSSProperties,
-  type ClipboardEvent,
-  type KeyboardEvent,
 } from 'react'
-import { findSkypeByKey, findSkypeByShortcode, SKYPE_SHORTCODE_RE, skypeEmojiUrl } from '@/lib/skypeEmojis'
 import { EVERYONE_BLOUB_PARTICIPANT } from '@/lib/agentVisualState'
 import { staticBloubAvatarUrl } from '@/lib/bloub/staticAvatar'
+import { findSkypeByKey, findSkypeByShortcode, SKYPE_SHORTCODE_RE, skypeEmojiUrl } from '@/lib/skypeEmojis'
 
 export interface MentionInfo {
   /** Display name shown after the `@` inside the chip. */
@@ -44,7 +44,7 @@ export interface RichInputHandle {
   getValue(): string
   /** Replace the entire content. Used when switching conversations or
    *  clearing after send. */
-  setValue(s: string): void
+  setValue(s: string, caretOffset?: number): void
   /** Insert plain text at the current caret position. Returns the new
    *  serialized value + caret offset. */
   insertText(s: string): void
@@ -371,6 +371,60 @@ function moveCaretToEnd(el: HTMLElement) {
   sel.addRange(range)
 }
 
+/** Restore a caret expressed in the editor's serialized text coordinates.
+ * Mention/emoji atoms count as their wire token length, while newlines are
+ * represented by BR nodes. This keeps picker replacements at the insertion
+ * point instead of jumping to the end (or onto a browser-created block). */
+function moveCaretToOffset(el: HTMLElement, requested: number) {
+  let remaining = Math.max(0, requested)
+  const range = document.createRange()
+  let placed = false
+  const visit = (node: Node) => {
+    if (placed) return
+    if (node.nodeType === Node.TEXT_NODE) {
+      const length = node.nodeValue?.length ?? 0
+      if (remaining <= length) {
+        range.setStart(node, remaining)
+        range.collapse(true)
+        placed = true
+      } else remaining -= length
+      return
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return
+    const element = node as HTMLElement
+    const mentionId = element.dataset.mentionId
+    const skypeKey = element.dataset.skypeEmoji
+    const atomLength = mentionId
+      ? mentionId.length + 1
+      : skypeKey ? (findSkypeByKey(skypeKey)?.shortcodes[0] ?? `(${skypeKey})`).length : 0
+    if (atomLength) {
+      if (remaining <= atomLength) {
+        range.setStartAfter(element)
+        range.collapse(true)
+        placed = true
+      } else remaining -= atomLength
+      return
+    }
+    if (element.tagName === 'BR') {
+      if (remaining <= 1) {
+        range.setStartAfter(element)
+        range.collapse(true)
+        placed = true
+      } else remaining -= 1
+      return
+    }
+    for (const child of Array.from(element.childNodes)) visit(child)
+  }
+  for (const child of Array.from(el.childNodes)) visit(child)
+  if (!placed) {
+    range.selectNodeContents(el)
+    range.collapse(false)
+  }
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
 export const RichInput = forwardRef<RichInputHandle, Props>(function RichInput(
   {
     defaultValue, placeholder, className, style, maxHeight,
@@ -452,13 +506,15 @@ export const RichInput = forwardRef<RichInputHandle, Props>(function RichInput(
       const el = elRef.current
       return el ? serializeNode(el) : ''
     },
-    setValue(s: string) {
+    setValue(s: string, caretOffset?: number) {
       const el = elRef.current
       if (!el) return
       inflate(s, el, resolveMentionRef.current)
       lastEmittedRef.current = s
-      moveCaretToEnd(el)
-      onChange?.(s, s.length)
+      const nextCaret = Math.min(Math.max(0, caretOffset ?? s.length), s.length)
+      if (caretOffset === undefined) moveCaretToEnd(el)
+      else moveCaretToOffset(el, nextCaret)
+      onChange?.(s, nextCaret)
     },
     insertText(s: string) {
       const el = elRef.current

--- a/src/desktop/ChatPane.tsx
+++ b/src/desktop/ChatPane.tsx
@@ -693,12 +693,13 @@ export function Composer({
     // Collapse any accidental double-trailing-space from sandwiching
     // the new mention next to an existing one.
     const next = `${before}${insert}${after}`.replace(/ {2,}$/, ' ')
+    const nextCaret = before.length + insert.length
     setMention(null)
     // setValue reflows the editor's DOM with the new text. Caret lands
     // at the end of the field — accepting this trade-off for the mid-
     // sentence insertion case keeps the composer rewrite small. Most
     // mentions are at the tail of a message anyway.
-    editorRef.current?.setValue(next)
+    editorRef.current?.setValue(next, nextCaret)
     requestAnimationFrame(() => editorRef.current?.focus())
   }
 
@@ -760,6 +761,20 @@ export function Composer({
     const skype = text.startsWith('(') ? findSkypeByShortcode(text) : undefined
     if (skype) editor.insertSkype(skype.key)
     else editor.insertText(text)
+  }
+
+  /** Toolbar shortcut for mentions. Preserve the editor selection (the
+   * button prevents mousedown blur) and insert an inline separator when the
+   * caret follows prose, so contenteditable never needs to create a DIV/BR
+   * wrapper to establish a mention boundary. */
+  const openMentionByButton = () => {
+    const editor = editorRef.current
+    if (!editor) return
+    const caret = editor.getCaretOffset()
+    const value = editor.getValue()
+    const previous = caret > 0 ? value[caret - 1] : ''
+    editor.insertText(previous && !/\s/.test(previous) ? ' @' : '@')
+    requestAnimationFrame(() => editor.focus())
   }
 
   const [emojiOpen, setEmojiOpen] = useState(false)
@@ -1170,7 +1185,7 @@ export function Composer({
           ><IClip className="w-[17px] h-[17px]" /></button>
           <button
             onMouseDown={(e) => e.preventDefault()}
-            onClick={() => insertAtCursor('@')}
+            onClick={openMentionByButton}
             className="w-7 h-7 rounded-[7px] grid place-items-center hover:bg-sky2-50 hover:text-skype-deep transition"
             title="提及成员"
           ><IAt className="w-[17px] h-[17px]" /></button>

--- a/src/lib/chatMessages.test.ts
+++ b/src/lib/chatMessages.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { hasBroadcastMention, withoutFinalizedActiveRuns } from './chatMessages'
+
+test('recognizes canonical @all and legacy @everyone broadcasts', () => {
+  assert.equal(hasBroadcastMention('@all 请都回答'), true)
+  assert.equal(hasBroadcastMention('请@all 都回答'), true)
+  assert.equal(hasBroadcastMention('@everyone answer'), true)
+  assert.equal(hasBroadcastMention('mail@all.example'), false)
+  assert.equal(hasBroadcastMention('@alligator'), false)
+})
+
+test('hides a persisted reply only while its matching markdown stream is active', () => {
+  const messages = [{ id: 'one', runId: 'run-1' }, { id: 'two', runId: 'run-2' }, { id: 'human' }]
+  assert.deepEqual(withoutFinalizedActiveRuns(messages, new Set(['run-1'])), [messages[1], messages[2]])
+  assert.equal(withoutFinalizedActiveRuns(messages, new Set()), messages)
+})

--- a/src/lib/chatMessages.ts
+++ b/src/lib/chatMessages.ts
@@ -1,0 +1,13 @@
+export function hasBroadcastMention(value: string): boolean {
+  return /(^|[^A-Za-z0-9_@])@(all|everyone)(?![\p{L}\p{N}_-])/iu.test(value.normalize('NFKC'))
+}
+
+/** Hide a durable Agent OS reply while its matching presentation stream is
+ * still open. Once stream.close removes the run id, the final row appears. */
+export function withoutFinalizedActiveRuns<T extends { runId?: string }>(
+  messages: T[],
+  activeRunIds: ReadonlySet<string>,
+): T[] {
+  if (activeRunIds.size === 0) return messages
+  return messages.filter((message) => !message.runId || !activeRunIds.has(message.runId))
+}

--- a/src/mobile/MobileChat.tsx
+++ b/src/mobile/MobileChat.tsx
@@ -346,7 +346,8 @@ export function MobileChat() {
     const at = slice.lastIndexOf('@')
     if (at < 0) { setMention(null); return }
     const before = at === 0 ? '' : text[at - 1]
-    if (before && !/\s/.test(before)) { setMention(null); return }
+    const followsMentionChip = /@[A-Za-z][\w-]*$/.test(text.slice(0, at))
+    if (before && !/\s/.test(before) && !followsMentionChip) { setMention(null); return }
     const after = slice.slice(at + 1)
     if (/\s/.test(after)) { setMention(null); return }
     if (after.length > 30) { setMention(null); return }
@@ -373,9 +374,10 @@ export function MobileChat() {
     const sep = before && !/\s$/.test(before) ? ' ' : ''
     const insert = `${sep}@${token} `
     const next = `${before}${insert}${after}`.replace(/ {2,}$/, ' ')
+    const nextCaret = before.length + insert.length
     setDraft(next)
     setMention(null)
-    editorRef.current?.setValue(next)
+    editorRef.current?.setValue(next, nextCaret)
     requestAnimationFrame(() => editorRef.current?.focus())
   }
 

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { type ApiMessage, api, type WsEvent, ws } from '@/api/client'
+import { hasBroadcastMention, withoutFinalizedActiveRuns } from '@/lib/chatMessages'
 import { isMockImDevelopment } from '@/lib/devMode'
 import { type ImEnvelope, isInternalAgentStatus, type LingxiMessageV1, lingxiIm } from '@/lib/im/wukong'
 import { useApp } from '@/stores/app'
@@ -23,7 +24,7 @@ export const VIRTUOSO_FIRST_INDEX_BASE = 1_000_000
 export interface MessagesState {
   byConvo: Record<string, Message[]>
   /** in-flight streaming bodies, keyed by message id */
-  streaming: Record<string, { body: string; conversationId: string; authorId: string; sequence: number }>
+  streaming: Record<string, { body: string; conversationId: string; authorId: string; sequence: number; mode?: 'markdown'; runId?: string }>
   /** which agents are currently typing in each conversation */
   typing: Record<string, string[]>
   loaded: Set<string>
@@ -300,6 +301,7 @@ function fromApi(m: ApiMessage): Message {
     clientId?: string | null
     mentionedIds?: string[] | null
     mentionAll?: boolean | null
+    runId?: string | null
     handoff?: Message['handoff'] | null
     approval?: Message['approval'] | null
     canvas?: Message['canvas'] | null
@@ -324,6 +326,7 @@ function fromApi(m: ApiMessage): Message {
     clientId: raw.clientId ?? undefined,
     mentionedIds: raw.mentionedIds ?? undefined,
     mentionAll: raw.mentionAll ?? undefined,
+    runId: raw.runId ?? undefined,
     handoff: raw.handoff ?? undefined,
     approval: raw.approval ?? undefined,
     canvas: raw.canvas ?? undefined,
@@ -374,6 +377,7 @@ function fromIm(message: ImEnvelope): Message {
       : undefined,
     mentionedIds: Array.isArray(data.mentionedIds) ? data.mentionedIds.map(String) : undefined,
     mentionAll: data.mentionAll === true,
+    runId: typeof payload.refs?.runId === 'string' ? payload.refs.runId : undefined,
   })
 }
 
@@ -398,6 +402,32 @@ function fromImBatch(messages: ImEnvelope[]): Message[] {
     byId.set(next.id, latest)
   }
   return sortMessagesStable([...byId.values()])
+}
+
+const activeReadTimers = new Map<string, number>()
+
+/** WuKong-delivered Agent OS messages do not necessarily have a matching app
+ * WebSocket message.new event. Mark the open room read from this transport as
+ * well, optimistically clearing its badge and debouncing the server cursor so
+ * a burst of streamed/final messages advances to the newest one. */
+function markConversationReadWhileOpen(conversationId: string): void {
+  void import('@/stores/conversations').then(({ useConversations }) => {
+    useConversations.setState((state) => ({
+      list: state.list.map((conversation) => conversation.id === conversationId
+        ? { ...conversation, unread: undefined }
+        : conversation),
+    }))
+  })
+  const current = activeReadTimers.get(conversationId)
+  if (current !== undefined) window.clearTimeout(current)
+  activeReadTimers.set(conversationId, window.setTimeout(() => {
+    activeReadTimers.delete(conversationId)
+    if (useApp.getState().selectedConversationId !== conversationId) return
+    void api.markRead(conversationId)
+      .then(() => import('@/stores/conversations'))
+      .then(({ useConversations }) => useConversations.getState().reload())
+      .catch(() => undefined)
+  }, 50))
 }
 
 function sequenceOf(m: Message): number | null {
@@ -697,7 +727,13 @@ export const useMessages = create<MessagesState>((set, get) => ({
 
 export const messagesFor = (s: MessagesState, convoId: string | null): Message[] => {
   if (!convoId) return EMPTY_MESSAGES
-  const base = s.byConvo[convoId] ?? EMPTY_MESSAGES
+  const stored = s.byConvo[convoId] ?? EMPTY_MESSAGES
+  const activeRunIds = new Set(Object.values(s.streaming)
+    .flatMap((entry) => entry.conversationId === convoId && entry.runId ? [entry.runId] : []))
+  // The durable final WuKong message can land just before stream.close.
+  // Keep showing the live Markdown row until that terminal event, then the
+  // already-cached final row takes over in the same timeline position.
+  const base = withoutFinalizedActiveRuns(stored, activeRunIds)
   const streaming = Object.entries(s.streaming)
     .filter(([id, x]) => x.conversationId === convoId
       // A streaming row's synthetic id never equals a real DB message id, so
@@ -718,7 +754,7 @@ export const messagesFor = (s: MessagesState, convoId: string | null): Message[]
       body: x.body,
       at: timeFromIso(),
       sequence: x.sequence,
-      streaming: x.body ? 'markdown' as const : 'placeholder' as const,
+      streaming: x.mode === 'markdown' || x.body ? 'markdown' as const : 'placeholder' as const,
     }))
   const streamingAuthors = new Set(streaming.map((message) => message.authorId))
   const meId = getMeId()
@@ -862,7 +898,7 @@ export async function sendUserMessage(
   }
 
   try {
-    const mentionAll = /(^|\s)@everyone\b/i.test(v)
+    const mentionAll = hasBroadcastMention(v)
     const mentionedIds = Object.values(useParticipants.getState().byId)
       .filter((participant) => participant.kind === 'agent')
       .filter((participant) => [participant.id, participant.name].some((label) => {
@@ -995,6 +1031,8 @@ export function bootMessagesStream() {
   // behind in the byConvo cache.
   clearAllTypingExpiries()
   clearAllStreamingExpiries()
+  for (const timer of activeReadTimers.values()) window.clearTimeout(timer)
+  activeReadTimers.clear()
   useMessages.setState({
     byConvo: {},
     streaming: {},
@@ -1014,10 +1052,10 @@ export function bootMessagesStream() {
           ...state.byConvo,
           [normalized.conversationId]: mergeFetchedMessages(state.byConvo[normalized.conversationId], [normalized]),
         },
-        ...(message.payload.kind === 'text' && message.payload.refs?.runId
-          ? { streaming: Object.fromEntries(Object.entries(state.streaming).filter(([id]) => id !== `preview-${message.payload.refs?.runId}`)) }
-          : {}),
       }))
+      if (message.channelId === useApp.getState().selectedConversationId) {
+        void markConversationReadWhileOpen(message.channelId)
+      }
     })
     lingxiIm.subscribeEvent((event) => {
       const id = event.clientMsgNo
@@ -1025,7 +1063,11 @@ export function bootMessagesStream() {
         useMessages.setState((state) => ({
           streaming: {
             ...state.streaming,
-            [id]: { body: event.text ?? '', conversationId: event.channelId, authorId: event.fromUid, sequence: Number.MAX_SAFE_INTEGER - 10 },
+            [id]: {
+              body: event.text ?? '', conversationId: event.channelId, authorId: event.fromUid,
+              sequence: Number.MAX_SAFE_INTEGER - 10, mode: 'markdown',
+              runId: id.startsWith('preview-') ? id.slice('preview-'.length) : undefined,
+            },
           },
         }))
         scheduleStreamingExpiry(id, event.channelId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,9 @@ export interface Message {
   /** Structured mention metadata resolved against the conversation roster. */
   mentionedIds?: string[]
   mentionAll?: boolean
+  /** Agent OS run identity used to hand off a live Markdown stream to its
+   * persisted final message without briefly rendering both. */
+  runId?: string
   at: string
   reactions?: ReactionEntry[]
   /** for tool messages */


### PR DESCRIPTION
## Summary
- keep quick mentions inline and restore the caret after replacing an `@query` on desktop and mobile
- recognize `@all` and legacy `@everyone` in both the composer payload and WuKong webhook fallback parsing
- render Agent OS preparation/output as one live Markdown stream and retain the working state until `stream.close`
- hide an early durable final reply behind its active stream to avoid duplicate/card flicker
- automatically clear unread state and advance the read cursor for WuKong messages arriving in the open conversation

## Verification
- `npm test` (229 passed)
- `npm run typecheck`
- `npm run server:typecheck`
- Biome checks for all changed files
- `git diff --check`