### PR TITLE
feat: add LingxiLoop project engineering skills

### DIFF
--- a/.agents/skills/lingxiloop-agent-os-change/SKILL.md
+++ b/.agents/skills/lingxiloop-agent-os-change/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: lingxiloop-agent-os-change
+description: "Implement, refactor, debug, or review LingxiLoop Agent OS, WuKongIM routing, Host Bridge, Canvas orchestration, model streaming, prompts, tools, sessions, or run events. Use for Agent OS changes, 智能体运行时改动, 消息路由, 工具调用, 并发恢复, or Canvas 编排 work where runtime contracts must remain intact."
+---
+
+# Change LingxiLoop Agent OS
+
+Preserve the independent Agent OS architecture while changing the smallest owning seam. Do not introduce a second agent runtime, model-facing product tool, or competing chat store.
+
+## Ground the change
+
+Read `README.md`, `docs/COORDINATION.md`, and `docs/RUNTIME_EVENT_STREAM.md`. Read `docs/CANVAS.md` for Canvas or Host Bridge work and `docs/open-notebook-native.md` for knowledge integration.
+
+Read [references/runtime-contracts.md](references/runtime-contracts.md) before modifying runtime composition, durable work, sessions, model/tool contracts, Host Actions, events, or IM routing.
+
+Trace the real path touched by the change:
+
+```text
+WuKong post-commit event -> validated receipt/work item -> leased Agent OS run
+-> session/model/IPython loop -> approved Host Bridge action or final message
+-> persisted event/control state and WuKong-visible result
+```
+
+Identify the authoritative state, transaction boundary, durable identity, retry point, cancellation point, and user-visible terminal outcome. Inspect both producer and consumer when changing a type, event, prompt, tool result, or endpoint.
+
+## Implement
+
+- Keep the model-visible tool list exactly strict `ipython`; expose product capability through the typed preloaded `loop` SDK.
+- Keep work and session mutations fenced by current lease identity. Preserve per-session serialization and isolated persistent kernels.
+- Reuse stable action and message identities across retries. Resume approved actions without replaying the original cell or completed side effect.
+- Keep previews ephemeral and publish exactly one durable final message through the authoritative chat path.
+- Treat retrieved knowledge, message bodies, attachments, model output, and tool JSON as untrusted at their boundary.
+- Track every cloud LLM call and terminal streaming usage in the cost ledger.
+- Update the owning architecture document when a shipped contract, event, default, or operator-visible behavior changes.
+
+Do not add compatibility paths, providers, tools, services, or shared execution environments without an explicit product decision.
+
+## Verify
+
+Add or update the narrowest test that fails for the regression, including negative and recovery cases. Depending on the seam, exercise cancellation, expired/stale fences, concurrent claims, retry after partial failure, duplicate webhook delivery, approval resume, cross-session isolation, and one-final-message behavior.
+
+Run the relevant subset selected by `$lingxiloop-verify-change`; Agent OS changes normally require:
+
+```text
+npm run guard:agent-os
+npm run guard:llm-tracked
+npm run server:typecheck
+npm test
+```
+
+Run `npm run test:integration` when PostgreSQL/Redis behavior, durable work, IM, Canvas, or Host Actions change. Leave Compose smoke to CI unless the isolated stack is available or the user requests a full rehearsal. Report unrun evidence explicitly.

--- a/.agents/skills/lingxiloop-agent-os-change/agents/openai.yaml
+++ b/.agents/skills/lingxiloop-agent-os-change/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "LingxiLoop Agent OS Change"
+  short_description: "Change Agent OS without breaking runtime contracts"
+  default_prompt: "Use $lingxiloop-agent-os-change to implement this Agent OS change safely."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/lingxiloop-agent-os-change/references/runtime-contracts.md
+++ b/.agents/skills/lingxiloop-agent-os-change/references/runtime-contracts.md
@@ -1,0 +1,53 @@
+# Agent OS Runtime Contracts
+
+Apply the sections reached by the change. Verify current code before relying on names in this guide.
+
+## Ownership map
+
+- `server/src/im/`: WuKong webhook validation, routing, reconciliation, and payload contracts.
+- `server/src/agent-os/`: control plane, durable queue, session/model loop, runtime, Host Bridge adapter, scheduling, memory, and watchdog.
+- `server/agent-os/kernel_runner.py`: isolated persistent IPython kernel process.
+- `server/src/agents/`: typed learning-domain actions, identity, coordination, observability, and LLM ledger.
+- `server/src/canvas/`: shared Canvas persistence and orchestration.
+- `src/lib/im/` and message stores: browser-side authoritative chat synchronization and preview reconciliation.
+
+## Durable work and sessions
+
+- Persist a validated webhook receipt and its `AgentWorkItem` atomically so a failed dispatch can retry without loss or duplication.
+- Use a monotonically increasing work fence plus opaque lease token. Every worker mutation that can outlive a claim must prove the current lease; cancellation must block new actionable side effects.
+- Serialize a session by `{companyId, agentId, channelId, threadRootClientMsgNo?}` while allowing unrelated sessions to run concurrently.
+- Renew or release the work lease and session lease coherently. Treat expiry, stop, preemption, and watchdog recovery as competing terminal transitions.
+- Persist session history with optimistic revision checks. Never let a stale worker overwrite a newer session.
+- Keep `runId` equal to the durable work id. Retried work must reuse externally visible identities.
+
+## Model and IPython
+
+- `MODEL_TOOLS` contains only `IPYTHON_TOOL`, with strict arguments containing exactly non-empty `code`.
+- The host owns history and provider conversion. Provider threads or alternate provider registries are not authoritative.
+- Keep kernel state isolated per Agent OS session. Durable knowledge belongs in Agent Home or typed `loop.*` services, not accidental Python globals alone.
+- Redact or fold raw code and internal output. User-visible activity must not reveal secrets, hidden prompt content, or unrestricted Python details.
+- Knowledge evidence is turn-local, untrusted data. Preserve marker-based citations and do not freeze retrieved excerpts into durable prompt context.
+
+## Host Actions and approvals
+
+- Identify an action by `{runId, cellId, callIndex}` and a deterministic idempotency key. Sink identities must collapse a replay after a post-side-effect crash.
+- Enforce tenant, agent, work, and resource ownership in the control plane even when the typed SDK already validates arguments.
+- Persist approval-required actions before surfacing approval. Resume only that action and inject its synthetic result; never replay the originating cell.
+- Execute denial at the final operation boundary. Prompts and schemas are guidance, not authorization.
+
+## Events and messaging
+
+- Keep per-run event sequence ordered. Distinguish internal events from learner-visible events.
+- Model deltas and activity are ephemeral previews. The durable final `LingxiMessageV1` sent through WuKongIM wins reconciliation.
+- Emit exactly one durable final response per completed logical work item. Recovery must not duplicate it.
+- Stop aborts the current request/cell; steer becomes the next highest-priority input and does not roll back completed side effects.
+- Agent-authored messages do not fan out without an explicit mention or typed handoff.
+
+## Required evidence by seam
+
+- Tool or parsing: `agent-os-tool` unit coverage and architecture guard.
+- Runtime/session/model conversion: focused runtime/model-driver tests plus stale revision and retry cases.
+- Queue/control plane: concurrency and `agent-os-reliability` integration coverage for claim, fence, cancellation, preemption, and recovery.
+- IM routing/webhook: duplicate delivery, transactional receipt, mention/reply routing, ordering, and final-message integration coverage.
+- Host Bridge/Canvas: idempotent sink, tenant/resource checks, approval resume, revision conflict, and isolated-execution integration coverage.
+- LLM call path: tracked-client or explicit streaming ledger accounting plus the ledger guard.

--- a/.agents/skills/lingxiloop-code-review/SKILL.md
+++ b/.agents/skills/lingxiloop-code-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: lingxiloop-code-review
+description: "Perform a read-only, repository-aware review of a LingxiLoop working tree, staged diff, commit range, branch, or pull request. Use for code review, PR review, merge-safety assessment, 审查代码, 检查改动, or 合并前检查; report evidence-backed findings without modifying code or Git state."
+---
+
+# Review LingxiLoop Changes
+
+Review the requested change against current product contracts and shipped behavior. Prefer a small number of proven defects over speculative warnings or style commentary.
+
+## Freeze the scope
+
+1. Identify the requested mode: working tree, staged diff, explicit commit range, branch, or PR.
+2. Record the exact base and head. Verify supplied refs locally or from live PR metadata. Never guess, fetch, switch branches, or mutate the checkout merely to obtain a base.
+3. Include untracked or local changes only when they are part of the requested scope. State anything excluded.
+4. Read the complete diff. When output truncates, inspect changed files individually.
+
+For a local classification of affected subsystems and relevant checks, run the sibling verifier in a matching scope mode:
+
+```text
+node .agents/skills/lingxiloop-verify-change/scripts/classify-change.mjs [scope options]
+```
+
+The classifier is evidence for coverage selection, not a substitute for semantic review.
+
+## Establish the contract
+
+Read `README.md` and `CONTRIBUTING.md`, then only the architecture documents that own the changed behavior. Read nested `AGENTS.md` files before reviewing vendored Open Notebook code. Treat tests and history as behavioral evidence, not automatic product authority.
+
+Read [references/review-contract.md](references/review-contract.md) for LingxiLoop-specific risk surfaces, severity, and output requirements.
+
+Trace both sides of every changed interface and enough callers, callees, persistence, and failure paths to establish reachability. Distinguish a verified defect from an unanswered product question.
+
+## Review the change
+
+Prioritize:
+
+- incorrect results, crashes, lost or cross-tenant data, authorization bypass, and unsafe external effects;
+- ordering, retry, lease, fencing, idempotency, transaction, cancellation, and partial-failure regressions;
+- broken Agent OS, WuKongIM, Host Bridge, model-visible, migration, packaging, or vendored-source contracts;
+- tests that cannot fail for the changed behavior, especially around security, concurrency, recovery, and migrations.
+
+Do not re-report issues already conclusively enforced by a passing repository gate unless the gate is bypassed or incomplete for this path. Do not demand unrelated refactors, speculative generality, or formatting preferences.
+
+Run focused, non-mutating checks only when they materially strengthen a claim or close a coverage gap. Record the exact command and result; never infer that an unrun check passed.
+
+## Report
+
+For each accepted finding, state the defect, tight location, reachable impact, governing contract, evidence, and a concrete correction direction. Use Codex `::code-comment` directives for localized findings with priority `0` through `3`; keep cross-cutting findings in the summary.
+
+Return findings in severity order, then list coverage, checks run, and explicit blind spots. If no actionable findings remain, say so without inventing one. Keep the review read-only: do not edit, stage, commit, push, post a GitHub review, or resolve threads unless the user separately authorizes that action.

--- a/.agents/skills/lingxiloop-code-review/agents/openai.yaml
+++ b/.agents/skills/lingxiloop-code-review/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "LingxiLoop Code Review"
+  short_description: "Review LingxiLoop changes against repository contracts"
+  default_prompt: "Use $lingxiloop-code-review to review this LingxiLoop change without modifying it."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/lingxiloop-code-review/references/review-contract.md
+++ b/.agents/skills/lingxiloop-code-review/references/review-contract.md
@@ -1,0 +1,57 @@
+# LingxiLoop Review Contract
+
+Use this reference for substantive reviews. Apply only the sections reached by the diff.
+
+## Sources of truth
+
+- `README.md`: current runtime boundary, authoritative stores, local verification, and deployment posture.
+- `CONTRIBUTING.md`: required gates and coding conventions.
+- `docs/COORDINATION.md`: wake routing, durable work, leases, session isolation, stop/steer, approvals, and recovery.
+- `docs/RUNTIME_EVENT_STREAM.md`: event visibility, previews, durable final messages, and control-plane behavior.
+- `docs/CANVAS.md`: shared state with isolated execution, revisions, Host Bridge actions, and realtime reconciliation.
+- `docs/RELEASE.md` and `docs/SHIPPING.md`: one-way cutover, digest-pinned release, evidence, smoke, and rollback.
+- `docs/open-notebook-native.md`, `third_party/open-notebook/UPSTREAM.md`, and nested `AGENTS.md`: native scope isolation and vendored-source provenance.
+
+When prose and implementation disagree, identify the current shipped behavior and the owning contract; do not silently choose one.
+
+## Mandatory risk surfaces
+
+### Tenant and trust boundaries
+
+- Derive tenant scope from authenticated or service-bound context, not a client-supplied company identifier.
+- Constrain tenant-owned reads, writes, joins, caches, events, and idempotency records by `company_id` or an equivalent owning relationship.
+- Check negative authorization paths and cross-tenant identifiers, not only the happy path.
+- Treat webhooks, model/tool JSON, retrieved knowledge, attachments, and external provider data as untrusted.
+
+### Agent OS and messaging
+
+- Keep the model-visible tool surface exactly strict `ipython`; product actions flow through the preloaded typed `loop` SDK.
+- Keep WuKongIM authoritative for chat content, ordering, read state, and offline synchronization. PostgreSQL may hold control-plane projections and durable work.
+- Preserve `{companyId, agentId, channelId, threadRootClientMsgNo?}` session isolation.
+- Require a current lease token and fence for worker mutations. Trace cancellation, steering, preemption, expiry, and retry races.
+- Preserve deterministic external identities: durable work id as run id, stable cell/call identity, and idempotency keys reused after recovery.
+- Publish exactly one durable final message. Treat model deltas and activity as previews, and keep raw Python internal or redacted.
+- Route every cloud LLM call through the tracked ledger path, including streaming completion accounting.
+
+### Persistence and migration
+
+- Use parameterized SQL, transactions for multi-write invariants, and durable idempotency for retryable side effects.
+- Verify boot migrations remain idempotent and safe with multiple pods and live traffic.
+- Update the current-schema sentinels when adding the latest required object; do not let lock-contention fallback skip a real migration.
+- Build large performance-only indexes concurrently and outside the main migration transaction. Do not make an optional optimization block boot.
+
+### Build, release, and vendored code
+
+- Treat workflow, lockfile, Docker, package, and release-script changes as credentialed supply-chain changes.
+- Preserve version synchronization, immutable image/tag assumptions, packaged Electron boundaries, and rollback evidence.
+- Under `third_party/open-notebook`, follow the closest `AGENTS.md`, preserve native scope-isolation tests, and update provenance when refreshing upstream.
+- Under OpenBot-tracked local files, preserve the pinned manifest/hash contract or update the provenance deliberately.
+
+## Severity and output
+
+- **P0:** immediately exploitable compromise, unrecoverable broad data loss, or repository-wide release emergency.
+- **P1:** merge-blocking correctness, security, tenant isolation, data integrity, availability, or recovery defect.
+- **P2:** material reachable bug, unsafe edge case, or missing regression coverage for risky changed behavior.
+- **P3:** localized actionable issue with limited impact. Omit preferences and non-actionable nits.
+
+Every finding needs a tight location, a reachable failure path, a binding expectation, and correction direction. Lower confidence or report a question when intent or reachability is unproven. Summarize reviewed areas as `finding`, `reviewed-clean`, or `not-covered`; never present partial coverage as complete.

--- a/.agents/skills/lingxiloop-db-change/SKILL.md
+++ b/.agents/skills/lingxiloop-db-change/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: lingxiloop-db-change
+description: "Implement, refactor, debug, or review LingxiLoop PostgreSQL DDL, runtime migrations, SQL persistence, indexes, backfills, transactions, tenant authorization, or data lifecycle behavior. Use for database changes, 数据库迁移, SQL 改动, 租户隔离, 数据回填, or 索引优化."
+---
+
+# Change the LingxiLoop Database
+
+Preserve tenant isolation, retry safety, and multi-replica boot behavior. Treat `server/src/db/migrate.ts` as the operational schema and migration source; `server/src/db/schema.ts` is a partial typed surface and must not be assumed complete.
+
+## Ground the change
+
+Read the changed persistence callers, `server/src/db/pool.ts`, the relevant migration section, and existing integration fixtures. Read `docs/RELEASE.md` for cutover or destructive migration work.
+
+Read [references/database-contracts.md](references/database-contracts.md) before changing DDL, tenant-owned queries, indexes, backfills, migration control flow, or retryable multi-write behavior.
+
+Map:
+
+- the table owner and tenant key;
+- every read/write caller and authorization source;
+- transaction and retry boundaries;
+- uniqueness, foreign key, and deletion behavior;
+- fresh install, already-current, upgrade, concurrent boot, and rollback behavior;
+- query shape and supporting index for growing or hot tables.
+
+## Implement
+
+- Parameterize values. Never interpolate user, tenant, agent, table, column, or sort input unless the identifier comes from a closed internal allowlist.
+- Derive tenant scope from authenticated membership or trusted service context and constrain every tenant-owned operation by `company_id` or an owning join.
+- Put state changes that must agree in one transaction. Make retryable external effects use durable idempotency rather than timing assumptions.
+- Shape boot DDL to be idempotent. Preserve the advisory-lock and bounded live-traffic lock behavior.
+- Add every latest required object to `schemaAlreadyCurrent`; otherwise lock-contention fallback can incorrectly skip the migration.
+- Keep correctness-required constraints and data transformations fatal. Build large performance-only indexes concurrently, outside the main migration transaction, and non-fatally when boot correctness does not depend on them.
+- Make destructive or one-way data changes explicit, evidence-backed, and compatible with the documented backup/rollback boundary. Do not invent a dual-write path.
+- Update typed surfaces, tests, operator docs, cleanup order, and seed/reset fixtures when their contract changes.
+
+## Verify
+
+Add behavior tests that would fail for missing tenant predicates, wrong joins, duplicate retries, partial commits, unsafe deletion, and re-running a migration. For schema work, verify both a fresh database and representative pre-existing rows; rerun the idempotent path.
+
+Use `$lingxiloop-verify-change` to select the exact set. Database changes normally require:
+
+```text
+npm run server:typecheck
+npm test
+npm run test:integration
+```
+
+Run the focused migration boot-retry test when retry or lock handling changes. Run Agent OS/LLM guards when the persisted contract belongs to those paths. If PostgreSQL, Redis, extensions, or production-sized data are unavailable, report that limitation and the CI or staging evidence still required.

--- a/.agents/skills/lingxiloop-db-change/agents/openai.yaml
+++ b/.agents/skills/lingxiloop-db-change/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "LingxiLoop Database Change"
+  short_description: "Make tenant-safe LingxiLoop database changes"
+  default_prompt: "Use $lingxiloop-db-change to implement this database change safely."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/lingxiloop-db-change/references/database-contracts.md
+++ b/.agents/skills/lingxiloop-db-change/references/database-contracts.md
@@ -1,0 +1,43 @@
+# LingxiLoop Database Contracts
+
+Apply only the sections reached by the change, and confirm current implementation details before editing.
+
+## Schema authority and boot
+
+- `server/src/db/migrate.ts` contains the effective PostgreSQL DDL and boot migration behavior.
+- `server/src/db/schema.ts` supplies selected Drizzle types; it is not a complete catalog of production columns or constraints.
+- `ensureSchema()` uses one session-scoped advisory lock to serialize migrators. The same connection must release it cleanly.
+- The advisory lock does not protect against live traffic. Keep the bounded DDL `lock_timeout` and boot retry behavior for `40P01` and `55P03`.
+- `schemaAlreadyCurrent()` may forgive a lock-contention failure only when all newest required objects exist. Update its sentinels in the same change as each new required table, column, constraint, or index.
+- Extensions and performance-only indexes may degrade gracefully only where application correctness has an explicit fallback.
+
+## Tenant and authorization
+
+- Treat `company_id` as part of the ownership identity for tenant data even when another identifier appears globally unique.
+- Resolve company membership server-side. A request body, URL, webhook, model call, or CLI argument does not establish authorization.
+- Constrain reads, updates, deletes, joins, conflict targets, cache keys, event publication, and background sweeps by the owning tenant relationship.
+- Validate both ends of tenant-owned links. A foreign identifier that exists in another tenant must be rejected, not silently linked.
+- Test the same identifier or plausible collision in two companies. Positive single-tenant coverage cannot prove isolation.
+
+## Transactions, retries, and lifecycle
+
+- Use one transaction for state that must publish or roll back together, such as webhook receipt plus work enqueue or mutation plus append-only audit event.
+- Acquire row locks or use conditional updates when concurrent writers compete for a state transition.
+- Give retryable side effects durable idempotency keys and terminal states. A process crash after the sink succeeds must not duplicate the effect.
+- Preserve cleanup and foreign-key order in integration reset helpers, retention workers, account deletion, and one-way cutovers.
+- Distinguish correctness data from caches, projections, and optimization indexes; their failure and recovery policies need not match.
+
+## Migration shapes
+
+- Prefer additive, idempotent DDL and explicit data transformations. Use `IF NOT EXISTS` only when the existing object's shape is independently guaranteed.
+- Make required backfills deterministic and restart-safe. Record progress or use conflict-safe predicates when one transaction is not credible.
+- Do not place a large ordinary `CREATE INDEX` on a hot table in the main DDL batch. Use `CREATE INDEX CONCURRENTLY` outside a transaction, remove invalid remnants, and keep it non-fatal only when it is performance-only.
+- Explain and test any nullable compatibility column or retained legacy field. Do not preserve dead schema by default.
+- For destructive cutovers, verify backup inputs and rollback restoration. Rollback may restore pre-cutover state; it need not reactivate retired runtimes.
+
+## Evidence
+
+- Unit-test parsing, retry classification, and pure query-building behavior where applicable.
+- Integration-test schema creation, representative upgrade data, idempotent rerun, tenant-negative access, constraints, and transaction rollback.
+- Exercise multi-replica or lock behavior with targeted mocks/tests when a reliable live concurrency reproduction is impractical.
+- Inspect query plans or production-like row counts before claiming an index or query change solves a performance problem.

--- a/.agents/skills/lingxiloop-verify-change/SKILL.md
+++ b/.agents/skills/lingxiloop-verify-change/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: lingxiloop-verify-change
+description: "Classify a LingxiLoop diff and run the smallest credible verification set, escalating risky or cross-domain changes toward the CI matrix. Use before claiming checks pass, pushing, handing off, or merging; also for 验证改动, 选择测试, 提交前检查, or 判断该跑哪些检查."
+---
+
+# Verify a LingxiLoop Change
+
+Select evidence from the actual outgoing scope. CI owns the exhaustive platform matrix, while local verification must exercise the narrowest check that would fail for the changed behavior.
+
+## Classify the scope
+
+Run the read-only classifier from the repository root:
+
+```text
+node .agents/skills/lingxiloop-verify-change/scripts/classify-change.mjs
+node .agents/skills/lingxiloop-verify-change/scripts/classify-change.mjs --base <verified-ref> [--head <ref>] [--include-worktree]
+```
+
+- With no `--base`, inspect staged, unstaged, and untracked paths only.
+- With `--base`, compare the verified merge base to `--head` or `HEAD`. The script never guesses or fetches a base.
+- Add `--include-worktree` only when local changes belong to that committed range.
+- Use `--format json` when another tool needs the versioned report.
+
+Read [references/check-matrix.md](references/check-matrix.md) before changing the classifier mapping or when a category needs manual interpretation.
+
+## Select and run evidence
+
+1. Inspect the classified paths and diff. Correct any path-only false positive or content-level omission before selecting checks.
+2. Run every available `required` check once.
+3. Run `recommended` checks when the behavior is reachable, the escalation applies, or the user requests stronger confidence. A missing database, Redis, Docker, platform, or credential is a recorded limitation, not a pass.
+4. Treat `CI-only` checks as a handoff unless the user requested a full local rehearsal and the environment supports it.
+5. Add a focused test when the classifier cannot name one but the changed behavior has an owning test. Do not use an unrelated green suite as proof.
+
+Do not run fix-mode linters, rewrite generated files, start deployment workflows, or mutate Git as part of verification unless separately authorized.
+
+## Report
+
+Report:
+
+- resolved scope and changed categories;
+- exact commands run, working directory when non-root, exit status, and relevant failure;
+- recommended or CI-only checks not run and why;
+- the strongest remaining blind spot;
+- `pass`, `fail`, or `incomplete` without overstating confidence.
+
+Do not claim a check passed because it is configured in CI or because a broader command was expected to include it. Reclassify after a merge, rebase, or material working-tree change.

--- a/.agents/skills/lingxiloop-verify-change/agents/openai.yaml
+++ b/.agents/skills/lingxiloop-verify-change/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "LingxiLoop Change Verification"
+  short_description: "Select evidence for the current LingxiLoop diff"
+  default_prompt: "Use $lingxiloop-verify-change to classify and verify this change."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/lingxiloop-verify-change/references/check-matrix.md
+++ b/.agents/skills/lingxiloop-verify-change/references/check-matrix.md
@@ -1,0 +1,40 @@
+# LingxiLoop Verification Matrix
+
+The classifier uses paths as a deterministic first pass. Inspect diff content before accepting the result, especially when ordinary API or agent-service files add SQL, LLM calls, authentication, or model-visible text.
+
+## Categories
+
+| Category | Typical paths | Minimum evidence |
+| --- | --- | --- |
+| `docs` | root Markdown, `docs/`, project Skills | brand guard and link/content inspection |
+| `frontend` | `src/`, `public/`, `website/`, Vite/Tailwind entry files | lint, frontend typecheck, owning tests; build when bundling or runtime entry behavior changes |
+| `server` | general `server/` runtime | lint, server typecheck, owning unit tests |
+| `agent-os-im-canvas` | Agent OS, agents, IM, Canvas, message-stream seams | Agent OS and LLM ledger guards, server typecheck, focused unit tests, reliability integration |
+| `database-tenant` | migrations, DB pool/schema, tenant/auth/onboarding and API persistence seams | server typecheck, migration/unit coverage, tenant-negative integration, full integration suite when schema or persisted contracts change |
+| `workers` | `workers/` | lint, worker/root tests, worker typecheck or build when its configuration changes |
+| `vendored` | `third_party/` | closest nested instructions, provenance checks, scoped upstream/native tests |
+| `build-release` | workflows, Compose, Dockerfiles, package/version, Electron/mobile packaging | version check, lint/typecheck/build as applicable, package/layout or Compose smoke in supported environments |
+
+Categories overlap deliberately. `agent-os-im-canvas` and `database-tenant` are specialized views of server risk, not evidence that a change is automatically cross-domain.
+
+## Escalation rules
+
+Recommend a full CI approximation when any of these applies:
+
+- a runtime migration or latest-schema sentinel changes;
+- workflow, dependency, package, Docker, Compose, version, or release machinery changes;
+- two or more primary runtime domains change in one diff;
+- vendored source or provenance changes;
+- the user explicitly asks for a full rehearsal or a CI failure is being reproduced.
+
+The local approximation is the applicable subset of brand, architecture and ledger guards; version check; lint; frontend/server typechecks; unit tests; integration tests; build; native Open Notebook scope test; Compose smoke; and desktop package layout smoke. Do not pretend platform- or service-dependent checks ran when they did not.
+
+## Selection details
+
+- Use direct owning test files when the relationship is clear. Otherwise run `npm test`; do not guess a narrow test from a similar filename.
+- Run `npm run test:integration` for schema, tenant authorization, durable work, IM routing, Host Bridge recovery, or multi-service persistence behavior when PostgreSQL and Redis are available.
+- Run `npm run guard:agent-os` for the active Agent OS composition and tool boundary.
+- Run `npm run guard:llm-tracked` whenever a server-side cloud LLM call or its wrapper can change.
+- Run the OpenBot vendor guard when a manifest-tracked file or its manifest changes.
+- Run the Open Notebook native scope test from `third_party/open-notebook` when that vendor subtree or its integration changes.
+- Treat `npm run mvp:ci:smoke` and desktop directory packaging as CI-only unless the local services and platform are already prepared.

--- a/.agents/skills/lingxiloop-verify-change/scripts/classify-change.mjs
+++ b/.agents/skills/lingxiloop-verify-change/scripts/classify-change.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const TIER_ORDER = new Map([
+  ['required', 0],
+  ['recommended', 1],
+  ['ci-only', 2],
+])
+
+const OPENBOT_TRACKED_PATHS = new Set([
+  'src/components/layout/detail-panel.tsx',
+  'src/components/ui/button.tsx',
+  'src/lib/motion.ts',
+])
+
+const CATEGORY_DEFINITIONS = [
+  {
+    id: 'docs',
+    reason: 'Documentation, contributor guidance, or repository-local Agent Skills changed.',
+    matches: (path) => path.startsWith('docs/')
+      || path.startsWith('.agents/skills/')
+      || /^(README|CONTRIBUTING|SECURITY|THIRD_PARTY_NOTICES)\.md$/.test(path),
+  },
+  {
+    id: 'frontend',
+    reason: 'Browser, website, assets, or frontend build inputs changed.',
+    matches: (path) => path.startsWith('src/')
+      || path.startsWith('public/')
+      || path.startsWith('website/')
+      || ['index.html', 'vite.config.ts', 'tailwind.config.ts', 'postcss.config.js'].includes(path),
+  },
+  {
+    id: 'server',
+    reason: 'Server runtime, tests, scripts, or service packaging changed.',
+    matches: (path) => path.startsWith('server/'),
+  },
+  {
+    id: 'agent-os-im-canvas',
+    reason: 'Agent OS, learning-agent services, IM, Canvas, or message-stream contracts changed.',
+    matches: (path) => path.startsWith('server/src/agent-os/')
+      || path.startsWith('server/agent-os/')
+      || path.startsWith('server/src/agents/')
+      || path.startsWith('server/src/im/')
+      || path.startsWith('server/src/canvas/')
+      || path === 'server/src/messages/stream-reply.ts'
+      || /^server\/src\/__tests__\/(agent-os|agents-|wukong|mentions|reply-stream|canvas|coworker-activity)/.test(path)
+      || /^server\/src\/__integration__\/(agent-os|agent-mute|canvas|polls)/.test(path)
+      || path.startsWith('src/lib/im/')
+      || path === 'src/stores/messages.ts'
+      || ['docs/COORDINATION.md', 'docs/RUNTIME_EVENT_STREAM.md', 'docs/CANVAS.md'].includes(path),
+  },
+  {
+    id: 'database-tenant',
+    reason: 'Schema, persistence, authentication, tenant resolution, or tenant-owned API behavior changed.',
+    matches: (path) => path.startsWith('server/src/db/')
+      || path.startsWith('server/src/api/')
+      || path === 'server/src/db-gc.ts'
+      || path === 'server/src/migrate-bin.ts'
+      || path === 'server/src/tenant.ts'
+      || path === 'server/src/auth.ts'
+      || path === 'server/src/admin.ts'
+      || path === 'server/src/onboardCompany.ts',
+  },
+  {
+    id: 'workers',
+    reason: 'A Cloudflare Worker implementation or its configuration changed.',
+    matches: (path) => path.startsWith('workers/'),
+  },
+  {
+    id: 'vendored',
+    reason: 'Vendored source, provenance, or vendor-scoped tests changed.',
+    matches: (path) => path.startsWith('third_party/') || OPENBOT_TRACKED_PATHS.has(path),
+  },
+  {
+    id: 'build-release',
+    reason: 'Build, dependency, CI, Compose, desktop, mobile, version, or release machinery changed.',
+    matches: (path) => path.startsWith('.github/workflows/')
+      || path.startsWith('electron/')
+      || path.startsWith('android/')
+      || path.startsWith('ios/')
+      || path.startsWith('server/docker/')
+      || /^docker-compose\..+\.yml$/.test(path)
+      || ['package.json', 'package-lock.json', 'VERSION', 'capacitor.config.ts', 'ecosystem.config.cjs'].includes(path)
+      || /^scripts\/(release|rollback|deploy|prepare|verify|sync-version|guard-openbot)/.test(path),
+  },
+]
+
+function normalizePath(value) {
+  return value.replaceAll('\\', '/').replace(/^\.\//, '').trim()
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.map(normalizePath).filter(Boolean))].sort((a, b) => a.localeCompare(b, 'en'))
+}
+
+function primaryDomain(path) {
+  const matched = new Set(CATEGORY_DEFINITIONS.filter((definition) => definition.matches(path)).map(({ id }) => id))
+  for (const id of ['vendored', 'workers', 'build-release', 'agent-os-im-canvas', 'database-tenant', 'frontend', 'server', 'docs']) {
+    if (matched.has(id)) return id
+  }
+  return 'other'
+}
+
+function addCheck(checks, command, tier, reason, cwd = '.') {
+  const key = `${cwd}\0${command}`
+  const existing = checks.get(key)
+  if (!existing) {
+    checks.set(key, { command, tier, reasons: [reason], ...(cwd === '.' ? {} : { cwd }) })
+    return
+  }
+  if (TIER_ORDER.get(tier) < TIER_ORDER.get(existing.tier)) existing.tier = tier
+  if (!existing.reasons.includes(reason)) existing.reasons.push(reason)
+}
+
+function selectChecks(paths, categoryIds, escalations) {
+  const checks = new Map()
+  const has = (id) => categoryIds.has(id)
+
+  if (paths.length > 0) {
+    addCheck(checks, 'npm run guard:brand', 'required', 'The brand guard scans every tracked and untracked text path.')
+  }
+
+  if (has('frontend')) {
+    addCheck(checks, 'npm run lint', 'required', 'Frontend TypeScript and React changes must satisfy Biome.')
+    addCheck(checks, 'npm run typecheck', 'required', 'Frontend types or bundler inputs changed.')
+    addCheck(checks, 'npm test', 'recommended', 'Run owning frontend tests and shared unit coverage.')
+    addCheck(checks, 'npm run build', 'recommended', 'Confirm Vite can build the changed frontend surface.')
+  }
+
+  if (has('server')) {
+    addCheck(checks, 'npm run lint', 'required', 'Server TypeScript and scripts must satisfy Biome.')
+    addCheck(checks, 'npm run server:typecheck', 'required', 'Server runtime types changed.')
+    addCheck(checks, 'npm test', 'required', 'Server behavior needs executable regression evidence.')
+    addCheck(checks, 'npm run guard:llm-tracked', 'recommended', 'Inspect whether the server diff can add or bypass a cloud LLM call.')
+  }
+
+  if (has('agent-os-im-canvas')) {
+    addCheck(checks, 'npm run guard:agent-os', 'required', 'The Agent OS composition and strict IPython tool boundary changed or is adjacent.')
+    addCheck(checks, 'npm run guard:llm-tracked', 'required', 'Agent runtime LLM usage must remain in the universal ledger.')
+    addCheck(checks, 'npm run server:typecheck', 'required', 'Agent OS, IM, Canvas, or Host Bridge types changed.')
+    addCheck(checks, 'npm test', 'required', 'Run Agent OS, IM, Canvas, and adjacent unit regressions.')
+    addCheck(checks, 'npm run test:integration', 'recommended', 'Durable work, IM, Canvas, and recovery contracts have integration coverage.')
+    addCheck(checks, 'npm run mvp:ci:smoke', 'ci-only', 'The isolated Compose smoke proves WuKong, durable work, IPython, and final reply together.')
+  }
+
+  if (has('database-tenant')) {
+    addCheck(checks, 'npm run server:typecheck', 'required', 'Persistence and tenant contracts are server typed.')
+    addCheck(checks, 'npm test', 'required', 'Migration helpers and tenant behavior need unit regression evidence.')
+    addCheck(checks, 'npm run test:integration', 'required', 'Schema, transaction, authorization, and tenant isolation require PostgreSQL/Redis evidence.')
+  }
+
+  if (has('workers')) {
+    addCheck(checks, 'npm run lint', 'required', 'Worker TypeScript must satisfy repository lint rules.')
+    addCheck(checks, 'npm test', 'required', 'The root test runner owns worker tests.')
+    const workerNames = new Set(paths
+      .filter((path) => path.startsWith('workers/'))
+      .map((path) => path.split('/')[1])
+      .filter(Boolean))
+    for (const name of [...workerNames].sort()) {
+      addCheck(checks, `npx tsc -p workers/${name}/tsconfig.json --noEmit`, 'recommended', `Typecheck the changed ${name} Worker with its own configuration.`)
+    }
+  }
+
+  if (has('vendored')) {
+    if (paths.some((path) => path.startsWith('third_party/openbot/')
+      || path === 'scripts/guard-openbot-vendor.mjs'
+      || OPENBOT_TRACKED_PATHS.has(path))) {
+      addCheck(checks, 'npm run guard:openbot-vendor', 'required', 'OpenBot-tracked files must match their pinned manifest hashes.')
+    }
+    if (paths.some((path) => path.startsWith('third_party/open-notebook/'))) {
+      addCheck(
+        checks,
+        'python -m pytest -q tests/test_lingxiloop_native_scope.py',
+        'required',
+        'The vendored Open Notebook integration must preserve LingxiLoop-native scope isolation.',
+        'third_party/open-notebook',
+      )
+    }
+  }
+
+  if (has('build-release')) {
+    addCheck(checks, 'npm run lint', 'required', 'Build and release scripts must satisfy repository lint rules.')
+    addCheck(checks, 'npm run typecheck', 'recommended', 'Build inputs may affect the frontend TypeScript graph.')
+    addCheck(checks, 'npm run server:typecheck', 'recommended', 'Server packaging inputs may affect the server TypeScript graph.')
+    addCheck(checks, 'npm run build', 'required', 'Build, dependency, or packaging inputs changed.')
+    if (paths.some((path) => ['VERSION', 'package.json', 'package-lock.json'].includes(path))) {
+      addCheck(checks, 'npm run version:check', 'required', 'VERSION, package manifest, and lockfile must agree.')
+    }
+    if (paths.some((path) => path.startsWith('electron/') || path === 'package.json' || path.startsWith('build/'))) {
+      addCheck(checks, 'npm run electron:prepare', 'ci-only', 'Prepare the isolated desktop package before platform layout smoke.')
+      addCheck(checks, 'node scripts/verify-desktop-package.mjs release', 'ci-only', 'Verify packaged Electron output excludes server/runtime sources and secrets.')
+    }
+    if (paths.some((path) => path.startsWith('docker-compose.') || path.startsWith('server/docker/') || path.startsWith('.github/workflows/'))) {
+      addCheck(checks, 'npm run mvp:ci:smoke', 'ci-only', 'CI Compose smoke covers multi-service packaging and runtime integration.')
+    }
+  }
+
+  if (escalations.some(({ id }) => id === 'full-ci-approximation')) {
+    for (const [command, reason] of [
+      ['npm run guard:agent-os', 'A high-risk diff warrants the architecture guard even when path classification is incomplete.'],
+      ['npm run guard:llm-tracked', 'A high-risk diff warrants a universal LLM ledger check.'],
+      ['npm run version:check', 'A high-risk diff warrants the version contract check.'],
+      ['npm run lint', 'A high-risk diff warrants repository lint.'],
+      ['npm run typecheck', 'A high-risk diff warrants frontend typecheck.'],
+      ['npm run server:typecheck', 'A high-risk diff warrants server typecheck.'],
+      ['npm test', 'A high-risk diff warrants the full local unit suite.'],
+      ['npm run build', 'A high-risk diff warrants a production frontend build.'],
+      ['npm run test:integration', 'Run the service-backed integration suite when PostgreSQL and Redis are available.'],
+    ]) addCheck(checks, command, 'recommended', reason)
+  }
+
+  return [...checks.values()]
+    .map((check) => ({ ...check, reasons: [...check.reasons].sort((a, b) => a.localeCompare(b, 'en')) }))
+    .sort((a, b) => TIER_ORDER.get(a.tier) - TIER_ORDER.get(b.tier)
+      || (a.cwd ?? '.').localeCompare(b.cwd ?? '.', 'en')
+      || a.command.localeCompare(b.command, 'en'))
+}
+
+export function classifyPaths(inputPaths) {
+  const paths = uniqueSorted(inputPaths)
+  const categories = CATEGORY_DEFINITIONS.map((definition) => {
+    const matchedPaths = paths.filter(definition.matches)
+    return matchedPaths.length === 0 ? null : {
+      id: definition.id,
+      paths: matchedPaths,
+      reasons: [definition.reason],
+    }
+  }).filter(Boolean)
+  const categoryIds = new Set(categories.map(({ id }) => id))
+  const escalations = []
+
+  const migrationPaths = paths.filter((path) => path === 'server/src/db/migrate.ts'
+    || path === 'server/src/migrate-bin.ts'
+    || path.startsWith('server/src/scripts/migrate-')
+    || /(^|\/)migrations?\//.test(path))
+  if (migrationPaths.length > 0) {
+    escalations.push({
+      id: 'runtime-migration',
+      reason: 'Runtime migration or upgrade behavior changed; verify fresh, upgrade, idempotent, and lock-contention paths.',
+      paths: migrationPaths,
+    })
+  }
+
+  const releasePaths = paths.filter((path) => CATEGORY_DEFINITIONS.find(({ id }) => id === 'build-release').matches(path))
+  if (releasePaths.length > 0) {
+    escalations.push({
+      id: 'build-release-surface',
+      reason: 'Credentialed CI, dependency, platform packaging, version, or release behavior changed.',
+      paths: releasePaths,
+    })
+  }
+
+  const vendorPaths = paths.filter((path) => CATEGORY_DEFINITIONS.find(({ id }) => id === 'vendored').matches(path))
+  if (vendorPaths.length > 0) {
+    escalations.push({
+      id: 'vendored-source',
+      reason: 'Vendored code requires provenance review and vendor-scoped tests.',
+      paths: vendorPaths,
+    })
+  }
+
+  const domains = new Set(paths.map(primaryDomain).filter((id) => !['docs', 'other'].includes(id)))
+  if (domains.size >= 2) {
+    escalations.push({
+      id: 'cross-domain',
+      reason: `The diff crosses primary domains: ${[...domains].sort().join(', ')}.`,
+      paths,
+    })
+  }
+
+  if (escalations.some(({ id }) => ['runtime-migration', 'build-release-surface', 'vendored-source', 'cross-domain'].includes(id))) {
+    escalations.push({
+      id: 'full-ci-approximation',
+      reason: 'Run the applicable full local quality matrix and leave unavailable platform/service checks to CI.',
+      paths,
+    })
+  }
+
+  const sortedEscalations = escalations
+    .map((item) => ({ ...item, paths: uniqueSorted(item.paths) }))
+    .sort((a, b) => a.id.localeCompare(b.id, 'en'))
+
+  return {
+    paths,
+    categories,
+    checks: selectChecks(paths, categoryIds, sortedEscalations),
+    escalations: sortedEscalations,
+  }
+}
+
+export function buildReport(paths, scope) {
+  const classified = classifyPaths(paths)
+  return {
+    version: 1,
+    scope,
+    paths: classified.paths,
+    categories: classified.categories,
+    checks: classified.checks,
+    escalations: classified.escalations,
+  }
+}
+
+export function renderText(report) {
+  const lines = [
+    'LingxiLoop change classification',
+    `Scope: ${report.scope.mode}`,
+  ]
+  if (report.scope.base) lines.push(`Base: ${report.scope.base.ref} (${report.scope.base.oid})`)
+  if (report.scope.head) lines.push(`Head: ${report.scope.head.ref} (${report.scope.head.oid})`)
+  if (report.scope.mergeBase) lines.push(`Merge base: ${report.scope.mergeBase}`)
+  lines.push(`Changed paths: ${report.paths.length}`)
+  for (const path of report.paths) lines.push(`  - ${path}`)
+
+  lines.push('Categories:')
+  if (report.categories.length === 0) lines.push('  - none')
+  for (const category of report.categories) lines.push(`  - ${category.id}: ${category.paths.length} path(s)`)
+
+  lines.push('Checks:')
+  if (report.checks.length === 0) lines.push('  - none')
+  for (const check of report.checks) {
+    const cwd = check.cwd ? ` [cwd: ${check.cwd}]` : ''
+    lines.push(`  - ${check.tier}: ${check.command}${cwd}`)
+    for (const reason of check.reasons) lines.push(`      ${reason}`)
+  }
+
+  lines.push('Escalations:')
+  if (report.escalations.length === 0) lines.push('  - none')
+  for (const escalation of report.escalations) lines.push(`  - ${escalation.id}: ${escalation.reason}`)
+  return `${lines.join('\n')}\n`
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    windowsHide: true,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || '').trim()
+    throw new Error(`git ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`)
+  }
+  return result.stdout
+}
+
+function resolveCommit(ref) {
+  return runGit(['rev-parse', '--verify', `${ref}^{commit}`]).trim()
+}
+
+function zeroSeparatedPaths(output) {
+  return output.split('\0').map(normalizePath).filter(Boolean)
+}
+
+function worktreePaths() {
+  return uniqueSorted([
+    ...zeroSeparatedPaths(runGit(['diff', '--name-only', '-z', 'HEAD', '--'])),
+    ...zeroSeparatedPaths(runGit(['ls-files', '--others', '--exclude-standard', '-z'])),
+  ])
+}
+
+function usage() {
+  return `Usage: node classify-change.mjs [--base <ref>] [--head <ref>] [--include-worktree] [--format text|json]\n`
+}
+
+export function parseArgs(argv) {
+  const options = { format: 'text', includeWorktree: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--help' || argument === '-h') return { ...options, help: true }
+    if (argument === '--include-worktree') {
+      options.includeWorktree = true
+      continue
+    }
+    if (argument === '--base' || argument === '--head' || argument === '--format') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`)
+      options[argument.slice(2)] = value
+      index += 1
+      continue
+    }
+    throw new Error(`unknown argument: ${argument}`)
+  }
+  if (options.head && !options.base) throw new Error('--head requires --base')
+  if (!['text', 'json'].includes(options.format)) throw new Error('--format must be text or json')
+  return options
+}
+
+function reportFromGit(options) {
+  if (!options.base) {
+    return buildReport(worktreePaths(), { mode: 'worktree' })
+  }
+
+  const headRef = options.head ?? 'HEAD'
+  const baseOid = resolveCommit(options.base)
+  const headOid = resolveCommit(headRef)
+  const mergeBase = runGit(['merge-base', baseOid, headOid]).trim()
+  const committedPaths = zeroSeparatedPaths(runGit(['diff', '--name-only', '-z', mergeBase, headOid, '--']))
+  const localPaths = options.includeWorktree ? worktreePaths() : []
+  return buildReport([...committedPaths, ...localPaths], {
+    mode: options.includeWorktree ? 'range+worktree' : 'range',
+    base: { ref: options.base, oid: baseOid },
+    head: { ref: headRef, oid: headOid },
+    mergeBase,
+  })
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2))
+    if (options.help) {
+      process.stdout.write(usage())
+      return
+    }
+    const report = reportFromGit(options)
+    process.stdout.write(options.format === 'json' ? `${JSON.stringify(report, null, 2)}\n` : renderText(report))
+  } catch (error) {
+    process.stderr.write(`[classify-change] ${error instanceof Error ? error.message : String(error)}\n`)
+    process.stderr.write(usage())
+    process.exitCode = 2
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main()

--- a/.agents/skills/lingxiloop-verify-change/scripts/classify-change.test.mjs
+++ b/.agents/skills/lingxiloop-verify-change/scripts/classify-change.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import { buildReport, classifyPaths, parseArgs, renderText } from './classify-change.mjs'
+
+const script = fileURLToPath(new URL('./classify-change.mjs', import.meta.url))
+
+function check(report, command) {
+  return report.checks.find((item) => item.command === command)
+}
+
+function category(report, id) {
+  return report.categories.find((item) => item.id === id)
+}
+
+function run(command, arguments_, cwd) {
+  const result = spawnSync(command, arguments_, { cwd, encoding: 'utf8', windowsHide: true })
+  if (result.error) throw result.error
+  return result
+}
+
+test('classifies docs-only changes without build evidence', () => {
+  const report = classifyPaths(['docs/CANVAS.md', 'README.md'])
+  assert.ok(category(report, 'docs'))
+  assert.equal(category(report, 'frontend'), undefined)
+  assert.equal(check(report, 'npm run guard:brand')?.tier, 'required')
+  assert.equal(check(report, 'npm run build'), undefined)
+  assert.equal(report.escalations.length, 0)
+})
+
+test('classifies frontend changes with typecheck and build evidence', () => {
+  const report = classifyPaths(['src/components/AppShell.tsx'])
+  assert.ok(category(report, 'frontend'))
+  assert.equal(check(report, 'npm run typecheck')?.tier, 'required')
+  assert.equal(check(report, 'npm run build')?.tier, 'recommended')
+})
+
+test('classifies Agent OS changes with architecture and ledger guards', () => {
+  const report = classifyPaths([
+    'server/src/agent-os/runtime.ts',
+    'server/src/__tests__/agent-os-runtime.test.ts',
+  ])
+  assert.ok(category(report, 'server'))
+  assert.ok(category(report, 'agent-os-im-canvas'))
+  assert.equal(check(report, 'npm run guard:agent-os')?.tier, 'required')
+  assert.equal(check(report, 'npm run guard:llm-tracked')?.tier, 'required')
+  assert.equal(report.escalations.some(({ id }) => id === 'cross-domain'), false)
+})
+
+test('escalates runtime migrations to the full CI approximation', () => {
+  const report = classifyPaths(['server/src/db/migrate.ts'])
+  assert.ok(category(report, 'database-tenant'))
+  assert.ok(report.escalations.some(({ id }) => id === 'runtime-migration'))
+  assert.ok(report.escalations.some(({ id }) => id === 'full-ci-approximation'))
+  assert.equal(check(report, 'npm run test:integration')?.tier, 'required')
+})
+
+test('selects vendor-specific checks', () => {
+  const report = classifyPaths([
+    'src/components/ui/button.tsx',
+    'third_party/open-notebook/open_notebook/domain/notebook.py',
+  ])
+  assert.ok(category(report, 'vendored'))
+  assert.equal(check(report, 'npm run guard:openbot-vendor')?.tier, 'required')
+  const nativeScope = check(report, 'python -m pytest -q tests/test_lingxiloop_native_scope.py')
+  assert.equal(nativeScope?.tier, 'required')
+  assert.equal(nativeScope?.cwd, 'third_party/open-notebook')
+})
+
+test('escalates independent runtime domains but not overlapping server categories', () => {
+  const crossDomain = classifyPaths(['server/src/agent-os/runtime.ts', 'src/components/AppShell.tsx'])
+  assert.ok(crossDomain.escalations.some(({ id }) => id === 'cross-domain'))
+  const serverOverlap = classifyPaths(['server/src/api/router.ts'])
+  assert.equal(serverOverlap.escalations.some(({ id }) => id === 'cross-domain'), false)
+})
+
+test('keeps paths and rendered output deterministic', () => {
+  const first = buildReport(['src/z.ts', 'README.md', 'src/a.ts', 'src/z.ts'], { mode: 'fixture' })
+  const second = buildReport(['src/a.ts', 'src/z.ts', 'README.md'], { mode: 'fixture' })
+  assert.deepEqual(first, second)
+  assert.deepEqual(first.paths, ['README.md', 'src/a.ts', 'src/z.ts'])
+  assert.equal(renderText(first), renderText(second))
+})
+
+test('handles an empty change set', () => {
+  const report = buildReport([], { mode: 'fixture' })
+  assert.deepEqual(report.paths, [])
+  assert.deepEqual(report.categories, [])
+  assert.deepEqual(report.checks, [])
+  assert.deepEqual(report.escalations, [])
+})
+
+test('validates CLI options', () => {
+  assert.deepEqual(parseArgs(['--base', 'main', '--head', 'topic', '--include-worktree', '--format', 'json']), {
+    base: 'main',
+    head: 'topic',
+    includeWorktree: true,
+    format: 'json',
+  })
+  assert.throws(() => parseArgs(['--head', 'topic']), /--head requires --base/)
+  assert.throws(() => parseArgs(['--format', 'yaml']), /text or json/)
+})
+
+test('reports invalid refs without a stack trace', () => {
+  const result = run(process.execPath, [script, '--base', 'definitely-missing-ref'], process.cwd())
+  assert.equal(result.status, 2)
+  assert.match(result.stderr, /classify-change/)
+  assert.doesNotMatch(result.stderr, /\n\s+at /)
+})
+
+test('default CLI mode includes untracked files and emits valid JSON', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'lingxiloop-classifier-'))
+  try {
+    assert.equal(run('git', ['init', '-q'], directory).status, 0)
+    assert.equal(run('git', ['config', 'user.email', 'classifier@test.invalid'], directory).status, 0)
+    assert.equal(run('git', ['config', 'user.name', 'Classifier Test'], directory).status, 0)
+    writeFileSync(join(directory, 'README.md'), '# Fixture\n')
+    assert.equal(run('git', ['add', 'README.md'], directory).status, 0)
+    assert.equal(run('git', ['commit', '-q', '-m', 'fixture'], directory).status, 0)
+    writeFileSync(join(directory, 'untracked.md'), 'new\n')
+
+    const result = run(process.execPath, [script, '--format', 'json'], directory)
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(result.stdout)
+    assert.equal(report.version, 1)
+    assert.equal(report.scope.mode, 'worktree')
+    assert.deepEqual(report.paths, ['untracked.md'])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- Add four repository-local, implicitly triggerable LingxiLoop engineering Skills under `.agents/skills`.
- Add deterministic `lingxiloop-verify-change` classification CLI with text/JSON output and tests.
- Add focused contracts for read-only review, Agent OS/WuKongIM changes, and database/tenant changes.

## Validation
- All four Skills pass `quick_validate.py`.
- Classifier passes `node --check` and `node --test` (11/11).
- `npm run lint` passes with only pre-existing warnings/suggestions.
- `npm run guard:brand` and `git diff --check` pass.

No LingxiLoop application runtime, database schema, or CI workflow files were changed.