### PR TITLE
fix: harden OAuth callbacks and packaged notifications

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -566,7 +566,7 @@ const NOTIF_MARGIN_TOP = 24
 
 function notificationUrl() {
   if (isDev) return `${DEV_URL}/#notifications`
-  return `file://${path.join(__dirname, '..', 'dist', 'index.html')}#notifications`
+  return 'app://lingxiloop/index.html#notifications'
 }
 
 function positionNotificationWindow() {

--- a/server/src/__tests__/oauth-return-url.test.ts
+++ b/server/src/__tests__/oauth-return-url.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isAllowedReturnUrl, matchesAllowedReturnUrl } from '../oauth-return-url.js'
+
+test('OAuth return allowlist compares HTTP URL components and path boundaries', () => {
+  const allowed = 'https://loop.example.com/auth'
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/auth', allowed), true)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/auth/done?n=abc', allowed), true)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/authentic', allowed), false)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com.example.invalid/auth', allowed), false)
+  assert.equal(matchesAllowedReturnUrl('http://loop.example.com/auth', allowed), false)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com:444/auth', allowed), false)
+  assert.equal(matchesAllowedReturnUrl('https://user@loop.example.com/auth', allowed), false)
+})
+
+test('OAuth return allowlist handles default ports and custom app callbacks', () => {
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com:443/path', 'https://loop.example.com/path'), true)
+  assert.equal(matchesAllowedReturnUrl('lingxiloop://auth?n=fresh', 'lingxiloop://auth'), true)
+  assert.equal(matchesAllowedReturnUrl('lingxiloop://auth/complete?n=fresh', 'lingxiloop://auth'), true)
+  assert.equal(matchesAllowedReturnUrl('lingxiloop://auth.evil?n=fresh', 'lingxiloop://auth'), false)
+  assert.equal(matchesAllowedReturnUrl('lingxiloop://authentic?n=fresh', 'lingxiloop://auth'), false)
+})
+
+test('OAuth return allowlist rejects malformed URLs and honors configured queries', () => {
+  assert.equal(isAllowedReturnUrl('not a url', ['https://loop.example.com/']), false)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/?channel=mobile', 'https://loop.example.com/?channel=desktop'), false)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/?channel=desktop', 'https://loop.example.com/?channel=desktop'), true)
+  assert.equal(matchesAllowedReturnUrl('https://loop.example.com/#preset', 'https://loop.example.com/'), false)
+})

--- a/server/src/api/router.ts
+++ b/server/src/api/router.ts
@@ -841,8 +841,8 @@ api.get('/metrics', async (req, res) => {
  *  we mint it server-side, save to Redis (5min TTL), and verify on the
  *  callback to defend against CSRF + cross-provider mixups.
  *
- *  `?return=<url>` is the post-callback redirect target. Must startsWith
- *  one of LINGXILOOP_AUTH_RETURN_ALLOWLIST entries; otherwise rejected so we
+ *  `?return=<url>` is the post-callback redirect target. Must semantically
+ *  match one of LINGXILOOP_AUTH_RETURN_ALLOWLIST entries; otherwise rejected so we
  *  can't be turned into an open redirect. Omit to use AUTH_DONE_URL. */
 api.get('/auth/start/:provider', safe(async (req, res) => {
   const provider = req.params.provider as Provider

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -154,8 +154,8 @@ export const env = {
   /** Allow-list of return URLs the client may pass via /auth/start
    *  `?return=...`. Without this we'd have an open-redirect: any
    *  attacker could craft a malicious provider-callback chain that
-   *  delivers the user's token to a foreign origin. A return URL is
-   *  accepted iff it startsWith one of these prefixes. Comma-separated.
+   *  delivers the user's token to a foreign origin. Entries are matched by
+   *  parsed scheme, host, effective port, and path boundary. Comma-separated.
    *  Common values:
    *    lingxiloop://auth                       (packaged Electron deep link)
    *    http://localhost:5173/              (Vite dev renderer)

--- a/server/src/oauth-return-url.ts
+++ b/server/src/oauth-return-url.ts
@@ -1,0 +1,40 @@
+/**
+ * Compare an OAuth return URL with one configured allow-list entry using URL
+ * semantics. Query parameters are intentionally not part of the boundary:
+ * clients use them for per-login state such as the native/desktop nonce.
+ */
+export function matchesAllowedReturnUrl(candidateRaw: string, allowedRaw: string): boolean {
+  let candidate: URL
+  let allowed: URL
+  try {
+    candidate = new URL(candidateRaw)
+    allowed = new URL(allowedRaw)
+  } catch {
+    return false
+  }
+
+  if (candidate.username || candidate.password || allowed.username || allowed.password) return false
+  if (candidate.hash || allowed.hash) return false
+  if (candidate.protocol !== allowed.protocol) return false
+  if (candidate.hostname !== allowed.hostname) return false
+  // URL.port normalizes explicit default ports (for example :443) to an
+  // empty string, so this compares effective ports rather than formatting.
+  if (candidate.port !== allowed.port) return false
+
+  const allowedPath = allowed.pathname
+  const candidatePath = candidate.pathname
+  const pathAllowed = allowedPath.endsWith('/')
+    ? candidatePath.startsWith(allowedPath)
+    : candidatePath === allowedPath || candidatePath.startsWith(`${allowedPath}/`)
+  if (!pathAllowed) return false
+
+  // If an operator deliberately configured a query, require those exact
+  // parameters. Entries without a query allow client-generated state params.
+  if (allowed.search && candidate.search !== allowed.search) return false
+  return true
+}
+
+export function isAllowedReturnUrl(candidate: string, allowlist: readonly string[]): boolean {
+  if (!candidate) return false
+  return allowlist.some((allowed) => matchesAllowedReturnUrl(candidate, allowed))
+}

--- a/server/src/oauth.ts
+++ b/server/src/oauth.ts
@@ -39,6 +39,7 @@ import { storage } from './storage.js'
 import { provisionUser as provisionSub2apiUser, sub2apiConfigured } from './sub2api.js'
 import { isWaitlistEnabled, enqueueWaitlist, isAllowlistedAdmin } from './admin.js'
 import { discoverOidc, normalizeOidcProfile, type OidcProfile } from './oidc.js'
+import { isAllowedReturnUrl } from './oauth-return-url.js'
 
 export type Provider = 'lingxi' | 'google' | 'github' | 'apple'
 
@@ -114,14 +115,10 @@ interface StateData {
 }
 
 /** Validate a client-supplied return URL against the configured allow-list.
- *  Without this we'd have an open redirect: an attacker could craft a
- *  provider-callback chain that delivers the user's token to any origin
- *  via the fragment. The check is a strict-prefix match so subpaths are
- *  fine (`http://localhost:5180/anything`) but origin spoofs aren't
- *  (`http://evil.com?https://loop.example.com/`). */
+ *  Parsed URL components are compared so serialized-prefix tricks cannot
+ *  spoof an allowed host, port, custom-scheme callback, or path boundary. */
 export function returnUrlAllowed(url: string): boolean {
-  if (!url) return false
-  return env.AUTH_RETURN_ALLOWLIST.some((prefix) => url.startsWith(prefix))
+  return isAllowedReturnUrl(url, env.AUTH_RETURN_ALLOWLIST)
 }
 
 /** Mint a state token, save it + the requested return URL + optional invite

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -14,7 +14,12 @@
 import { useState, useEffect } from 'react'
 import { api, getServerOrigin } from '@/api/client'
 import { isElectron } from '@/lib/runtime'
-import { isNativePlatform, runOAuth } from '@/lib/native'
+import {
+  armNativeOAuthHandoff,
+  handleNativeOAuthCallback,
+  isNativePlatform,
+  runOAuth,
+} from '@/lib/native'
 import { CloudLogo } from './Avatar'
 import { WindowDragStrip } from './WindowDragStrip'
 
@@ -100,7 +105,8 @@ export function AuthScreen() {
         setBusy(null)
         return
       }
-      const ret = encodeURIComponent('lingxiloop://auth')
+      const nonce = armNativeOAuthHandoff()
+      const ret = encodeURIComponent(`lingxiloop://auth?n=${encodeURIComponent(nonce)}`)
       void (async () => {
         try {
           const callbackUrl = await runOAuth({
@@ -112,18 +118,14 @@ export function AuthScreen() {
             setBusy(null)
             return
           }
-          // ASWebAuthenticationSession delivers the final URL with the
-          // token fragment. Plant it as our `location.hash` so AuthGate's
-          // existing fragment-consumption logic picks it up.
-          const u = new URL(callbackUrl)
-          const hash = u.hash || (u.search ? `#${u.search.replace(/^\?/, '')}` : '')
-          if (!hash) {
-            setErr('登录已完成，但未返回登录凭证。')
+          // ASWebAuthenticationSession returns the same untrusted callback URL
+          // as the OS deep-link path. Validate its one-time nonce before
+          // exposing the token fragment to AuthGate.
+          if (!await handleNativeOAuthCallback(callbackUrl)) {
+            setErr('登录回调验证失败，请重试。')
             setBusy(null)
             return
           }
-          history.replaceState(null, '', location.pathname + location.search + hash)
-          window.dispatchEvent(new CustomEvent('lingxiloop:oauth-token', { detail: hash }))
         } catch (err) {
           setErr(err instanceof Error ? err.message : '登录失败')
           setBusy(null)

--- a/src/lib/electronNotificationUrl.test.ts
+++ b/src/lib/electronNotificationUrl.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+test('packaged notification window uses the registered app protocol', () => {
+  const source = readFileSync(new URL('../../electron/main.cjs', import.meta.url), 'utf8')
+  const body = source.match(/function notificationUrl\(\) \{([\s\S]*?)\n\}/)?.[1] ?? ''
+  assert.match(body, /app:\/\/lingxiloop\/index\.html#notifications/)
+  assert.doesNotMatch(body, /file:\/\//)
+})

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -16,6 +16,7 @@ import { Keyboard } from '@capacitor/keyboard'
 import { SplashScreen } from '@capacitor/splash-screen'
 import { StatusBar, Style } from '@capacitor/status-bar'
 import { registerPlugin } from '@capacitor/core'
+import { armNativeOAuth, consumeNativeOAuthCallback } from './nativeOAuthState'
 
 /**
  * iOS-only bridge to `ASWebAuthenticationSession` — Apple's dedicated
@@ -188,25 +189,32 @@ async function handleDeepLink(rawUrl: string): Promise<void> {
     // pathname `//auth`), so the host-based check silently missed and the OAuth
     // token was dropped on Android. The string match is parser-independent.
     if (/^lingxiloop:\/\/auth(?:[/?#]|$)/i.test(rawUrl)) {
-      // Pull the fragment (or a query-shaped token) straight out of the raw
-      // URL so we don't depend on the parser splitting host vs path correctly.
-      const hashIdx = rawUrl.indexOf('#')
-      const qIdx = rawUrl.indexOf('?')
-      const hash = hashIdx >= 0
-        ? rawUrl.slice(hashIdx)
-        : (qIdx >= 0 ? `#${rawUrl.slice(qIdx + 1)}` : '')
-      console.log('[native] OAuth deep link, hash=', hash)
-      if (hash) {
-        history.replaceState(null, '', location.pathname + location.search + hash)
-        window.dispatchEvent(new CustomEvent('lingxiloop:oauth-token', { detail: hash }))
-      }
-      await Browser.close().catch(() => undefined)
+      await handleNativeOAuthCallback(rawUrl)
       return
     }
     window.dispatchEvent(new CustomEvent('lingxiloop:deep-link', { detail: rawUrl }))
   } catch (err) {
     console.warn('[native] deep-link parse failed', rawUrl, err)
   }
+}
+
+/** Arm a mobile OAuth attempt and return the nonce to include in its return URL. */
+export function armNativeOAuthHandoff(): string {
+  return armNativeOAuth()
+}
+
+/** Accept a native OAuth callback only when it matches the armed attempt. */
+export async function handleNativeOAuthCallback(rawUrl: string): Promise<boolean> {
+  const callback = consumeNativeOAuthCallback(rawUrl)
+  if (!callback) {
+    console.warn('[native] dropped OAuth callback without a matching login nonce')
+    await Browser.close().catch(() => undefined)
+    return false
+  }
+  history.replaceState(null, '', location.pathname + location.search + callback.hash)
+  window.dispatchEvent(new CustomEvent('lingxiloop:oauth-token', { detail: callback.hash }))
+  await Browser.close().catch(() => undefined)
+  return true
 }
 
 /**

--- a/src/lib/nativeOAuthState.test.ts
+++ b/src/lib/nativeOAuthState.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  armNativeOAuth,
+  clearNativeOAuthForTest,
+  consumeNativeOAuthCallback,
+} from './nativeOAuthState'
+
+test.afterEach(clearNativeOAuthForTest)
+
+test('mobile OAuth callback requires and consumes the armed nonce', () => {
+  const nonce = armNativeOAuth(1_000)
+  const callback = `lingxiloop://auth?n=${nonce}#token=session-token&companyId=co-1`
+
+  assert.deepEqual(consumeNativeOAuthCallback(callback, 2_000), {
+    hash: '#token=session-token&companyId=co-1',
+  })
+  assert.equal(consumeNativeOAuthCallback(callback, 2_001), null, 'matched callback is single-use')
+})
+
+test('mobile OAuth callback rejects missing, mismatched, expired, and spoofed callbacks', () => {
+  const nonce = armNativeOAuth(1_000)
+  assert.equal(consumeNativeOAuthCallback('lingxiloop://auth#token=session-token', 2_000), null)
+  assert.equal(consumeNativeOAuthCallback('lingxiloop://auth?n=wrong#token=session-token', 2_000), null)
+  assert.equal(consumeNativeOAuthCallback('lingxiloop://auth.evil?n=' + nonce + '#token=session-token', 2_000), null)
+  assert.equal(consumeNativeOAuthCallback(`lingxiloop://auth?n=${nonce}#token=session-token`, 601_001), null)
+})
+
+test('mismatched callback does not consume the legitimate pending attempt', () => {
+  const nonce = armNativeOAuth(1_000)
+  assert.equal(consumeNativeOAuthCallback('lingxiloop://auth?n=wrong#token=attacker-token', 2_000), null)
+  assert.equal(consumeNativeOAuthCallback(`lingxiloop://auth?n=${nonce}`, 2_000), null)
+  assert.deepEqual(
+    consumeNativeOAuthCallback(`lingxiloop://auth?n=${nonce}#token=real-token`, 2_001),
+    { hash: '#token=real-token' },
+  )
+})
+
+test('arming a new mobile OAuth attempt supersedes the prior nonce', () => {
+  const oldNonce = armNativeOAuth(1_000)
+  const newNonce = armNativeOAuth(2_000)
+  assert.notEqual(newNonce, oldNonce)
+  assert.equal(consumeNativeOAuthCallback(`lingxiloop://auth?n=${oldNonce}#token=old-token`, 3_000), null)
+  assert.deepEqual(
+    consumeNativeOAuthCallback(`lingxiloop://auth?n=${newNonce}#token=new-token`, 3_000),
+    { hash: '#token=new-token' },
+  )
+})

--- a/src/lib/nativeOAuthState.ts
+++ b/src/lib/nativeOAuthState.ts
@@ -1,0 +1,75 @@
+const AUTH_NONCE_TTL_MS = 10 * 60 * 1000
+const AUTH_CALLBACK_PATTERN = /^lingxiloop:\/\/auth(?:[/?#]|$)/i
+
+interface ArmedAuth {
+  nonce: string
+  expiresAt: number
+}
+
+export interface NativeOAuthCallback {
+  /** Fragment to plant on the renderer URL, including the leading #. */
+  hash: string
+}
+
+let armedAuth: ArmedAuth | null = null
+
+function randomNonce(): string {
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/** Arm one mobile login attempt. A later attempt supersedes the old one. */
+export function armNativeOAuth(now = Date.now()): string {
+  const nonce = randomNonce()
+  armedAuth = { nonce, expiresAt: now + AUTH_NONCE_TTL_MS }
+  return nonce
+}
+
+function equalNonce(actual: string, expected: string): boolean {
+  if (actual.length !== expected.length) return false
+  let difference = 0
+  for (let i = 0; i < actual.length; i++) {
+    difference |= actual.charCodeAt(i) ^ expected.charCodeAt(i)
+  }
+  return difference === 0
+}
+
+/**
+ * Validate and consume an OAuth callback against the in-memory login attempt.
+ * Missing/mismatched callbacks do not consume a valid pending attempt; a match
+ * does, making replay impossible. Expired state is cleared eagerly.
+ */
+export function consumeNativeOAuthCallback(
+  rawUrl: string,
+  now = Date.now(),
+): NativeOAuthCallback | null {
+  if (!AUTH_CALLBACK_PATTERN.test(rawUrl)) return null
+  const pending = armedAuth
+  if (!pending) return null
+  if (now > pending.expiresAt) {
+    armedAuth = null
+    return null
+  }
+
+  const hashIndex = rawUrl.indexOf('#')
+  const queryIndex = rawUrl.indexOf('?')
+  const queryEnd = hashIndex >= 0 ? hashIndex : rawUrl.length
+  const query = queryIndex >= 0 && queryIndex < queryEnd
+    ? rawUrl.slice(queryIndex + 1, queryEnd)
+    : ''
+  const nonce = new URLSearchParams(query).get('n')
+  if (!nonce || !equalNonce(nonce, pending.nonce)) return null
+
+  // The server always appends the OAuth result as a fragment after the
+  // nonce-bearing return URL. Do not burn the pending attempt on an empty URL.
+  if (hashIndex < 0 || hashIndex === rawUrl.length - 1) return null
+  const hash = rawUrl.slice(hashIndex)
+
+  armedAuth = null
+  return { hash }
+}
+
+export function clearNativeOAuthForTest(): void {
+  armedAuth = null
+}


### PR DESCRIPTION
## Summary

- validate OAuth return URLs by parsed scheme, hostname, effective port, credentials, and path boundaries
- bind mobile OAuth callbacks to a cryptographically random, expiring, single-use nonce
- load the packaged Electron notification renderer through `app://lingxiloop`
- add regression coverage for URL spoofing, nonce mismatch/expiry/replay, and the notification URL

## Validation

- `npm test` (291 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run server:typecheck`
- `npm run build`

Closes #70
Closes #71
Closes #72